### PR TITLE
lcio::ILDCellID0 is inside this include we need this

### DIFF
--- a/source/Refitting/include/DDCellsAutomatonMV.h
+++ b/source/Refitting/include/DDCellsAutomatonMV.h
@@ -16,7 +16,7 @@
 #include <IMPL/TrackImpl.h>
 #include <IMPL/TrackerHitPlaneImpl.h>
 #include <UTIL/BitField64.h>
-/* #include <UTIL/ILDConf.h> */
+#include <UTIL/ILDConf.h>
 
 // KiTrack tools
 #include "KiTrack/SubsetHopfieldNN.h"


### PR DESCRIPTION
This fixes the problem with 
```
DDCellsAutomatonMV.h:134:104: error: 'lcio::ILDCellID0' has not been declared
```
this is defined in `UTIL/ILDConf.h`