### PR TITLE
Fix warnings

### DIFF
--- a/source/Digitisers/src/DDPlanarDigiProcessor.cc
+++ b/source/Digitisers/src/DDPlanarDigiProcessor.cc
@@ -180,7 +180,7 @@ void DDPlanarDigiProcessor::init() {
 }
 
 
-void DDPlanarDigiProcessor::processRunHeader( LCRunHeader* run) { 
+void DDPlanarDigiProcessor::processRunHeader( LCRunHeader* ) {
   ++_nRun ;
 } 
 
@@ -468,7 +468,7 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
 
 
 
-void DDPlanarDigiProcessor::check( LCEvent * evt ) { 
+void DDPlanarDigiProcessor::check( LCEvent* ) {
   // nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 

--- a/source/Digitisers/src/DDSpacePointBuilder.cc
+++ b/source/Digitisers/src/DDSpacePointBuilder.cc
@@ -158,7 +158,7 @@ void DDSpacePointBuilder::init() {
 }
 
 
-void DDSpacePointBuilder::processRunHeader( LCRunHeader* run) { 
+void DDSpacePointBuilder::processRunHeader( LCRunHeader* ) {
 
   _nRun++ ;
 } 
@@ -430,7 +430,7 @@ void DDSpacePointBuilder::processEvent( LCEvent * evt ) {
 
 
 
-void DDSpacePointBuilder::check( LCEvent * evt ) {}
+void DDSpacePointBuilder::check( LCEvent* ) {}
 
 
 void DDSpacePointBuilder::end(){
@@ -656,7 +656,7 @@ TrackerHitImpl* DDSpacePointBuilder::createSpacePoint( TrackerHitPlane* a , Trac
   
   if( fabs(du_a - du_b) > 1.0e-06 ){
     streamlog_out( ERROR ) << "\tThe measurement errors of the two 1D hits must be equal \n\n";    
-    assert( fabs(du_a - du_b) > 1.0e-06 == false );
+    assert( (fabs(du_a - du_b) > 1.0e-06) == false );
     return NULL; //measurement errors are not equal don't create a spacepoint
   }
  

--- a/source/Digitisers/src/PlanarDigiProcessor.cc
+++ b/source/Digitisers/src/PlanarDigiProcessor.cc
@@ -143,7 +143,7 @@ void PlanarDigiProcessor::init() {
   
 }
 
-void PlanarDigiProcessor::processRunHeader( LCRunHeader* run) { 
+void PlanarDigiProcessor::processRunHeader( LCRunHeader* ) {
   ++_nRun ;
 } 
 
@@ -403,7 +403,7 @@ void PlanarDigiProcessor::processEvent( LCEvent * evt ) {
 
 
 
-void PlanarDigiProcessor::check( LCEvent * evt ) { 
+void PlanarDigiProcessor::check( LCEvent*  ) {
   // nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 

--- a/source/Digitisers/src/SimpleCylinderDigiProcessor.cc
+++ b/source/Digitisers/src/SimpleCylinderDigiProcessor.cc
@@ -112,7 +112,7 @@ void SimpleCylinderDigiProcessor::init() {
   
 }
 
-void SimpleCylinderDigiProcessor::processRunHeader( LCRunHeader* run) { 
+void SimpleCylinderDigiProcessor::processRunHeader( LCRunHeader* ) {
   ++_nRun ;
 } 
 
@@ -275,7 +275,7 @@ void SimpleCylinderDigiProcessor::processEvent( LCEvent * evt ) {
 
 
 
-void SimpleCylinderDigiProcessor::check( LCEvent * evt ) { 
+void SimpleCylinderDigiProcessor::check( LCEvent* ) {
   // nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 

--- a/source/Digitisers/src/SimpleDiscDigiProcessor.cc
+++ b/source/Digitisers/src/SimpleDiscDigiProcessor.cc
@@ -164,7 +164,7 @@ void SimpleDiscDigiProcessor::init() {
   
 }
 
-void SimpleDiscDigiProcessor::processRunHeader( LCRunHeader* run) { 
+void SimpleDiscDigiProcessor::processRunHeader( LCRunHeader* ) {
   _nRun++ ;
 } 
 
@@ -592,7 +592,7 @@ void SimpleDiscDigiProcessor::processEvent( LCEvent * evt ) {
 
 
 
-void SimpleDiscDigiProcessor::check( LCEvent * evt ) { 
+void SimpleDiscDigiProcessor::check( LCEvent*  ) {
   // nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 
@@ -666,7 +666,7 @@ bool SimpleDiscDigiProcessor::hasCorrectZPos ( SimTrackerHit* hit ){
 
 
 
-int SimpleDiscDigiProcessor::getPetalNumber ( int layer , double x , double y ){
+int SimpleDiscDigiProcessor::getPetalNumber ( int /*layer*/, double x , double y ){
   
   
   
@@ -692,12 +692,12 @@ int SimpleDiscDigiProcessor::getSensorNumber ( int layer , double x , double y )
   
   //find out the sensor
   
-  double r = sqrt ( x*x + y*y ); //radius in xy plane
+  double radius = sqrt ( x*x + y*y ); //radius in xy plane
   
   // The relative radial position: from 0 to 1. 
   // 0.0 means at the inner radius of the petal.
   // 1.0 means at the outer radius of the petal.
-  double posRel = (r - _diskInnerRadius[layer]) / ( _diskOuterRadius[layer] - _diskInnerRadius[layer] ); 
+  double posRel = (radius - _diskInnerRadius[layer]) / ( _diskOuterRadius[layer] - _diskInnerRadius[layer] );
   
   
   int sensor = int ( posRel * _sensorsPerPetal ); //the number of the sensor

--- a/source/Digitisers/src/SimplePlanarDigiProcessor.cc
+++ b/source/Digitisers/src/SimplePlanarDigiProcessor.cc
@@ -141,7 +141,7 @@ void SimplePlanarDigiProcessor::init() {
   
 }
 
-void SimplePlanarDigiProcessor::processRunHeader( LCRunHeader* run) { 
+void SimplePlanarDigiProcessor::processRunHeader( LCRunHeader* ) {
   ++_nRun ;
 } 
 
@@ -522,7 +522,7 @@ void SimplePlanarDigiProcessor::processEvent( LCEvent * evt ) {
 
 
 
-void SimplePlanarDigiProcessor::check( LCEvent * evt ) { 
+void SimplePlanarDigiProcessor::check( LCEvent* ) {
   // nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 

--- a/source/Digitisers/src/SpacePointBuilder.cc
+++ b/source/Digitisers/src/SpacePointBuilder.cc
@@ -137,7 +137,7 @@ void SpacePointBuilder::init() {
 }
 
 
-void SpacePointBuilder::processRunHeader( LCRunHeader* run) { 
+void SpacePointBuilder::processRunHeader( LCRunHeader* ) {
 
   _nRun++ ;
 } 
@@ -405,7 +405,7 @@ void SpacePointBuilder::processEvent( LCEvent * evt ) {
 
 
 
-void SpacePointBuilder::check( LCEvent * evt ) {}
+void SpacePointBuilder::check( LCEvent* ) {}
 
 
 void SpacePointBuilder::end(){
@@ -579,7 +579,7 @@ TrackerHitImpl* SpacePointBuilder::createSpacePoint( TrackerHitPlane* a , Tracke
   
   if( fabs(du_a - du_b) > 1.0e-06 ){
     streamlog_out( ERROR ) << "\tThe measurement errors of the two 1D hits must be equal \n\n";    
-    assert( fabs(du_a - du_b) > 1.0e-06 == false );
+    assert( (fabs(du_a - du_b) > 1.0e-06) == false );
     return NULL; //measurement errors are not equal don't create a spacepoint
   }
  

--- a/source/Refitting/src/CellsAutomatonMV.cc
+++ b/source/Refitting/src/CellsAutomatonMV.cc
@@ -734,8 +734,9 @@ void CellsAutomatonMV::processEvent( LCEvent * evt ) {
       
       
       TrackImpl* trackImpl = new TrackImpl( *(myTrack->getLcioTrack()) );   // possible leak
-      const EVENT::TrackState * init_ts = trackImpl->getTrackState(lcio::TrackState::AtIP) ;
-      const EVENT::FloatVec covMatrixTest = trackImpl->getCovMatrix() ;
+      // const EVENT::TrackState * init_ts = trackImpl->getTrackState(lcio::TrackState::AtIP) ;
+      // const EVENT::FloatVec covMatrixTest = trackImpl->getCovMatrix() ;
+
       //--------------------------------------------------------------------------------------------------------------------------------------------------------------------
       // Create a new vector of hits, where we keep the 2D hits coming from 2D hits mini-vectors, but the 1D hits mini-vectors are turned back to the initial spacepoints
       // The reason for doing so is to be compatible with the trackerhit extended classes, that maps the @D hits and composite spacepoints to extended hits

--- a/source/Refitting/src/CellsAutomatonMV.cc
+++ b/source/Refitting/src/CellsAutomatonMV.cc
@@ -317,7 +317,7 @@ void CellsAutomatonMV::init() {
 }
 
 
-void CellsAutomatonMV::processRunHeader( LCRunHeader* run) { 
+void CellsAutomatonMV::processRunHeader( LCRunHeader* ) {
     
 } 
 
@@ -649,7 +649,7 @@ void CellsAutomatonMV::processEvent( LCEvent * evt ) {
   TrackCompatibilityShare1_MV comp;
 
   // Various ways to define the quality of a track. They are defined in  the header file
-  TrackQISpecial_MV  testQty;
+  // TrackQISpecial_MV  testQty;
   MaxHits TheMoreTheMerrier ;
 
   streamlog_out(DEBUG4) << " best subset finder = " << _bestSubsetFinder << " no of tracks fed to the nnets " << trackCandidates.size() << std::endl ;
@@ -714,7 +714,7 @@ void CellsAutomatonMV::processEvent( LCEvent * evt ) {
       
       std::vector< IMiniVector* > MVTrkHits =   myTrack->getMVs();
 
-      for (int mv = 0 ; mv <  MVTrkHits.size() ; mv++ ){
+      for (unsigned int mv = 0 ; mv <  MVTrkHits.size() ; mv++ ){
 	
 	MiniVector *testMV = MVTrkHits[mv]->getMiniVector() ;
 	TrackerHitVec spchits = testMV->getTrackerHitVec() ;
@@ -808,7 +808,7 @@ void CellsAutomatonMV::processEvent( LCEvent * evt ) {
 }
 
 
-void CellsAutomatonMV::check( LCEvent * evt ) { 
+void CellsAutomatonMV::check( LCEvent* ) {
   // nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 
@@ -1014,16 +1014,16 @@ void CellsAutomatonMV::InitialiseVTX( LCEvent * evt, EVENT::TrackerHitVec HitsTe
 
 void CellsAutomatonMV::CreateMiniVectors( int sector ) {
 
-  int iTheta = sector/(_nLayers*_nDivisionsInPhi) ;
-  int iPhi = ((sector - (iTheta*_nLayers*_nDivisionsInPhi)) / _nLayers) ;
-  int layer = sector - (iTheta*_nLayers*_nDivisionsInPhi) - (iPhi*_nLayers) ; 
+  int thisTheta = sector/(_nLayers*_nDivisionsInPhi) ;
+  int thisPhi = ((sector - (thisTheta*_nLayers*_nDivisionsInPhi)) / _nLayers) ;
+  int layer = sector - (thisTheta*_nLayers*_nDivisionsInPhi) - (thisPhi*_nLayers) ;
 
-  streamlog_out(DEBUG4) << " Taking sector " << sector << " of layer " << layer << " Phi sector " << iPhi << " Theta sector " << iTheta << std::endl ;
+  streamlog_out(DEBUG4) << " Taking sector " << sector << " of layer " << layer << " Phi sector " << thisPhi << " Theta sector " << thisTheta << std::endl ;
 
-  int iPhi_Up    = iPhi + 2;
-  int iPhi_Low   = iPhi - 2;
-  int iTheta_Up  = iTheta + 2; 
-  int iTheta_Low = iTheta - 2;
+  int iPhi_Up    = thisPhi + 2;
+  int iPhi_Low   = thisPhi - 2;
+  int iTheta_Up  = thisTheta + 2;
+  int iTheta_Low = thisTheta - 2;
   if (iTheta_Low < 0) iTheta_Low = 0;
   if (iTheta_Up  >= _nDivisionsInTheta) iTheta_Up = _nDivisionsInTheta-1;
 
@@ -1058,8 +1058,8 @@ void CellsAutomatonMV::CreateMiniVectors( int sector ) {
 	  // construct mini-vectors applying a delta theta cut
 	  //***************************************************************************
 	  
-	  int iTheta_Up_mod  = iTheta + 2; 
-	  int iTheta_Low_mod = iTheta - 2;
+	  int iTheta_Up_mod  = thisTheta + 2;
+	  int iTheta_Low_mod = thisTheta - 2;
 	  if (iTheta_Low_mod < 0) iTheta_Low_mod = 0;
 	  if (iTheta_Up_mod  >= _nDivisionsInTheta) iTheta_Up_mod = _nDivisionsInTheta-1;
 	  
@@ -1112,13 +1112,13 @@ void CellsAutomatonMV::CreateMiniVectors( int sector ) {
       
 	if ( layer==10 || layer==8) {
 	  
-	  int iPhi_Up_Mod    = iPhi + 8;
-	  int iPhi_Low_Mod   = iPhi - 8;
+	  int iPhi_Up_Mod    = thisPhi + 8;
+	  int iPhi_Low_Mod   = thisPhi - 8;
 	  
 	  for (int iPhi = iPhi_Low_Mod ; iPhi < iPhi_Up_Mod ; iPhi++){
 	    
-	    int iTheta_Up_mod  = iTheta + 8; 
-	    int iTheta_Low_mod = iTheta - 8;
+	    int iTheta_Up_mod  = thisTheta + 8;
+	    int iTheta_Low_mod = thisTheta - 8;
 	    if (iTheta_Low_mod < 0) iTheta_Low_mod = 0;
 	    if (iTheta_Up_mod  >= _nDivisionsInTheta) iTheta_Up_mod = _nDivisionsInTheta-1;
 	    
@@ -1395,7 +1395,7 @@ bool CellsAutomatonMV::thetaAgreementImproved( EVENT::TrackerHit *toHit, EVENT::
   bool agreement = false ;
 
   //double resolution = 0.004 ; // just temporarily here
-  double MPS_factor = 0.0 ;  // just for test, and only for vertical muons of 4GeV
+  //double MPS_factor = 0.0 ;  // just for test, and only for vertical muons of 4GeV
 
   double  pos_outer[3];
   double  pos_inner[3];

--- a/source/Refitting/src/DDCellsAutomatonMV.cc
+++ b/source/Refitting/src/DDCellsAutomatonMV.cc
@@ -898,8 +898,8 @@ void DDCellsAutomatonMV::InitialiseVTX( LCEvent * evt, EVENT::TrackerHitVec Hits
       TrackerHitPlane*     trkhit_P = 0;
       TrackerHitZCylinder* trkhit_C = 0;
       
-      double drphi(NAN);
-      double dz(NAN);
+      //double drphi(NAN);
+      //double dz(NAN);
       
       for (int ielem=0; ielem<nelem; ++ielem) {
 	
@@ -943,8 +943,8 @@ void DDCellsAutomatonMV::InitialiseVTX( LCEvent * evt, EVENT::TrackerHitVec Hits
 
 	  streamlog_out(DEBUG1) << " We deal with composite spacepoints " << std::endl ;
 	  
-	  drphi =  2 * sqrt(trkhit->getCovMatrix()[0] + trkhit->getCovMatrix()[2]);         
-	  dz    =      sqrt(trkhit->getCovMatrix()[5]);         
+	  //drphi =  2 * sqrt(trkhit->getCovMatrix()[0] + trkhit->getCovMatrix()[2]);
+	  //dz    =      sqrt(trkhit->getCovMatrix()[5]);
 	  
 	} 
 	// or a PIXEL based SIT, using 2D TrackerHitPlane like the VXD above
@@ -969,22 +969,22 @@ void DDCellsAutomatonMV::InitialiseVTX( LCEvent * evt, EVENT::TrackerHitVec Hits
 	    exit(1);
 	  }
 	  
-	  drphi = trkhit_P->getdU();
-	  dz    = trkhit_P->getdV();                                                 
+	  //drphi = trkhit_P->getdU();
+	  //dz    = trkhit_P->getdV();
 	  
 	} 
 	// or a simple cylindrical design, as used in the LOI      
 	else if ( ( trkhit_C = dynamic_cast<TrackerHitZCylinder*>( hitCollection->getElementAt( ielem ) ) ) ) {
 	  
-	  drphi = trkhit_C->getdRPhi();
-	  dz    = trkhit_C->getdZ();
+	  //drphi = trkhit_C->getdRPhi();
+	  //dz    = trkhit_C->getdZ();
 	  
 	} 
 	// this would be very unlikely, but who knows ... just an ordinary TrackerHit, which is not a COMPOSITE_SPACEPOINT
 	else {
 	  
-	  drphi =  2 * sqrt(trkhit->getCovMatrix()[0] + trkhit->getCovMatrix()[2]);         
-	  dz =     sqrt(trkhit->getCovMatrix()[5]);             
+	  //drphi =  2 * sqrt(trkhit->getCovMatrix()[0] + trkhit->getCovMatrix()[2]);
+	  //dz =     sqrt(trkhit->getCovMatrix()[5]);
 	  
 	}
 	

--- a/source/Refitting/src/DDCellsAutomatonMV.cc
+++ b/source/Refitting/src/DDCellsAutomatonMV.cc
@@ -316,7 +316,7 @@ void DDCellsAutomatonMV::init() {
 }
 
 
-void DDCellsAutomatonMV::processRunHeader( LCRunHeader* run) { 
+void DDCellsAutomatonMV::processRunHeader( LCRunHeader* ) {
     
 } 
 
@@ -658,8 +658,8 @@ void DDCellsAutomatonMV::processEvent( LCEvent * evt ) {
   // Various ways to define the quality of a track. They are defined in  the header file
   //TrackQIChi2Prob_MV whatever;
   //TrackQISpecial_MV JustDoIt ;
-  TrackQI trackQI;
-  MaxHits MaxLength;
+  //TrackQI trackQI;
+  //MaxHits MaxLength;
   Test test;
 
 
@@ -779,7 +779,7 @@ void DDCellsAutomatonMV::processEvent( LCEvent * evt ) {
 }
 
 
-void DDCellsAutomatonMV::check( LCEvent * evt ) { 
+void DDCellsAutomatonMV::check( LCEvent* ) {
   // nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 
@@ -1043,16 +1043,16 @@ void DDCellsAutomatonMV::InitialiseVTX( LCEvent * evt, EVENT::TrackerHitVec Hits
 
 void DDCellsAutomatonMV::CreateMiniVectors( int sector ) {
 
-  int iTheta = sector/(_nLayers*_nDivisionsInPhi) ;
-  int iPhi = ((sector - (iTheta*_nLayers*_nDivisionsInPhi)) / _nLayers) ;
-  int layer = sector - (iTheta*_nLayers*_nDivisionsInPhi) - (iPhi*_nLayers) ; 
+  int thisTheta = sector/(_nLayers*_nDivisionsInPhi) ;
+  int thisPhi = ((sector - (thisTheta*_nLayers*_nDivisionsInPhi)) / _nLayers) ;
+  int layer = sector - (thisTheta*_nLayers*_nDivisionsInPhi) - (thisPhi*_nLayers) ;
 
-  streamlog_out(DEBUG4) << " Taking sector " << sector << " of layer " << layer << " Phi sector " << iPhi << " Theta sector " << iTheta << std::endl ;
+  streamlog_out(DEBUG4) << " Taking sector " << sector << " of layer " << layer << " Phi sector " << thisPhi << " Theta sector " << thisTheta << std::endl ;
 
-  int iPhi_Up    = iPhi + 2;
-  int iPhi_Low   = iPhi - 2;
-  int iTheta_Up  = iTheta + 2; 
-  int iTheta_Low = iTheta - 2;
+  int iPhi_Up    = thisPhi + 2;
+  int iPhi_Low   = thisPhi - 2;
+  int iTheta_Up  = thisTheta + 2;
+  int iTheta_Low = thisTheta - 2;
   if (iTheta_Low < 0) iTheta_Low = 0;
   if (iTheta_Up  >= _nDivisionsInTheta) iTheta_Up = _nDivisionsInTheta-1;
 
@@ -1087,8 +1087,8 @@ void DDCellsAutomatonMV::CreateMiniVectors( int sector ) {
 	  // construct mini-vectors applying a delta theta cut
 	  //***************************************************************************
 	  
-	  int iTheta_Up_mod  = iTheta + 2; 
-	  int iTheta_Low_mod = iTheta - 2;
+	  int iTheta_Up_mod  = thisTheta + 2;
+	  int iTheta_Low_mod = thisTheta - 2;
 	  if (iTheta_Low_mod < 0) iTheta_Low_mod = 0;
 	  if (iTheta_Up_mod  >= _nDivisionsInTheta) iTheta_Up_mod = _nDivisionsInTheta-1;
 	  
@@ -1148,8 +1148,8 @@ void DDCellsAutomatonMV::CreateMiniVectors( int sector ) {
 	  
 	  for (int iPhi = iPhi_Low ; iPhi < iPhi_Up ; iPhi++){
 	    
-	    int iTheta_Up_mod  = iTheta + 10; 
-	    int iTheta_Low_mod = iTheta - 10;
+	    int iTheta_Up_mod  = thisTheta + 10;
+	    int iTheta_Low_mod = thisTheta - 10;
 	    if (iTheta_Low_mod < 0) iTheta_Low_mod = 0;
 	    if (iTheta_Up_mod  >= _nDivisionsInTheta) iTheta_Up_mod = _nDivisionsInTheta-1;
 	    
@@ -1419,7 +1419,7 @@ bool DDCellsAutomatonMV::thetaAgreementImproved( EVENT::TrackerHit *toHit, EVENT
   bool agreement = false ;
 
   //double resolution = 0.004 ; // just temporarily here
-  double MPS_factor = 0.0 ;  // just for test, and only for vertical muons of 4GeV
+  //double MPS_factor = 0.0 ;  // just for test, and only for vertical muons of 4GeV
 
   double  pos_outer[3];
   double  pos_inner[3];

--- a/source/Refitting/src/ExtrToSIT.cc
+++ b/source/Refitting/src/ExtrToSIT.cc
@@ -222,7 +222,7 @@ void ExtrToSIT::init() {
   
 }
 
-void ExtrToSIT::processRunHeader( LCRunHeader* run) { 
+void ExtrToSIT::processRunHeader( LCRunHeader* ) {
   
   ++_n_run ;
 } 
@@ -273,12 +273,12 @@ void ExtrToSIT::processEvent( LCEvent * evt ) {
     std::vector< IMPL::TrackImpl* > trackCandidates ;
 
     // loop over the input tracks and refit using KalTest    
-    for(int i=0; i< nTracks ; ++i) {
+    for(int iTrack=0; iTrack< nTracks ; ++iTrack) {
 
       int SITHitsPerTrk = 0 ;
       
       //Track* track = dynamic_cast<Track*>( input_track_col->getElementAt( i ) ) ;
-      Track* track = dynamic_cast<Track*>( inputTrackVec->getElementAt( i ) ) ;
+      Track* track = static_cast<Track*>( inputTrackVec->getElementAt( iTrack ) ) ;
       
       MarlinTrk::IMarlinTrack* marlin_trk = _trksystem->createTrack();
       
@@ -301,9 +301,7 @@ void ExtrToSIT::processEvent( LCEvent * evt ) {
 	// sort the hits in R, so here we are assuming that the track came from the IP and that we want to fit out to in. 
 	sort(trkHits.begin(), trkHits.end(), ExtrToSIT::compare_r() );
 	
-	EVENT::TrackerHitVec::iterator it = trkHits.begin();
-	
-	for( it = trkHits.begin() ; it != trkHits.end() ; ++it ){
+	for(EVENT::TrackerHitVec::iterator it = trkHits.begin() ; it != trkHits.end() ; ++it ){
 	  marlin_trk->addHit(*it);
 	}
 	
@@ -362,7 +360,6 @@ void ExtrToSIT::processEvent( LCEvent * evt ) {
 	    
 	    double chi2 = 0 ;
 	    int ndf = 0 ;
-	    TrackStateImpl trkState;	
 	    
 	    gear::Vector3D xing_point ; 
 	    
@@ -382,7 +379,7 @@ void ExtrToSIT::processEvent( LCEvent * evt ) {
 
 	    //for loop to all SIT layers
 	    
-	    for (int iL=0;iL<nSITR;iL++){
+	    for (unsigned int iL=0;iL<nSITR;iL++){
 	      
 	      if ( sitHitsCol != 0 ){
 		
@@ -400,7 +397,8 @@ void ExtrToSIT::processEvent( LCEvent * evt ) {
 
 		layerID = encoder.lowWord() ;  
 	      
-		  
+		TrackStateImpl trkState;
+
 		if ( marlin_trk->propagateToLayer( layerID, trkState, chi2, ndf, elementID, IMarlinTrack::modeClosest) == MarlinTrk::IMarlinTrack::success) {
 		    
 		  const FloatVec& covLCIO = trkState.getCovMatrix();
@@ -442,9 +440,9 @@ void ExtrToSIT::processEvent( LCEvent * evt ) {
 		    
 		    double chi2_increment = 0;
 		    
-		    for (int i=0;i<sitHits;i++){
+		    for (int iSit=0;iSit<sitHits;iSit++){
 		      
-		      TrackerHit* hit = dynamic_cast<TrackerHit*>( sitHitsCol->getElementAt( i ) ) ;
+		      TrackerHit* hit = dynamic_cast<TrackerHit*>( sitHitsCol->getElementAt( iSit ) ) ;
 		      
 		      streamlog_out(DEBUG2) << " type = " << hit->getType() << std::endl;
 		      
@@ -467,16 +465,16 @@ void ExtrToSIT::processEvent( LCEvent * evt ) {
 		      
 		      // Just to check the element matching between the hit (coming from the digitiser) and the track extrapolation element (coming from Mokka)
 		      
-		      int mokkaLayerNumber = 0 ;
-		      int mokkaLadderNumber = 0 ;
-		      int mokkaSideTest = 0 ;
-		      int mokkaSensorNumber = 0 ;
+		      // int mokkaLayerNumber = 0 ;
+		      // int mokkaLadderNumber = 0 ;
+		      // int mokkaSideTest = 0 ;
+		      // int mokkaSensorNumber = 0 ;
 		      
 		      encoder.setValue(elementID) ;
-		      mokkaLayerNumber  = encoder[lcio::LCTrackerCellID::layer()] ;
-		      mokkaLadderNumber = encoder[lcio::LCTrackerCellID::module()] ;
-		      mokkaSideTest = encoder[lcio::LCTrackerCellID::side()] ;
-		      mokkaSensorNumber = encoder[lcio::LCTrackerCellID::sensor()] ;
+		      // mokkaLayerNumber  = encoder[lcio::LCTrackerCellID::layer()] ;
+		      // mokkaLadderNumber = encoder[lcio::LCTrackerCellID::module()] ;
+		      // mokkaSideTest = encoder[lcio::LCTrackerCellID::side()] ;
+		      // mokkaSensorNumber = encoder[lcio::LCTrackerCellID::sensor()] ;
 		      encoder.reset() ;
 		      
 		      streamlog_out(DEBUG2) << " checking hit : type = " << hit->getType() << " cell ID = " << celId << " side = " << sideTest << " layer = " << layerNumber << " ladder = " << ladderNumber << " sensor = " << sensorNumber << std::endl ;
@@ -633,14 +631,15 @@ void ExtrToSIT::processEvent( LCEvent * evt ) {
 	      }
 	      
 	      
-	      bool fit_backwards = IMarlinTrack::backward;
+	      // bool fit_backwards = IMarlinTrack::backward;
 	      bool fit_forwards = IMarlinTrack::forward;
 	      MarlinTrk::IMarlinTrack* marlinTrk = _trksystem->createTrack();		
-	      int error = 0;
+	      // int error = 0;
 	      
 	      try {
 		
-		error = MarlinTrk::createFinalisedLCIOTrack(marlinTrk, trkHits, refittedTrack, fit_forwards, covMatrix, _bField, _maxChi2PerHit);                              
+		// int error =
+		MarlinTrk::createFinalisedLCIOTrack(marlinTrk, trkHits, refittedTrack, fit_forwards, covMatrix, _bField, _maxChi2PerHit);
 		
 	      } catch (...) {
 		
@@ -755,7 +754,7 @@ void ExtrToSIT::processEvent( LCEvent * evt ) {
 
 
 
-void ExtrToSIT::check( LCEvent * evt ) { 
+void ExtrToSIT::check( LCEvent* ) {
   // nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 
@@ -772,7 +771,7 @@ void ExtrToSIT::end(){
 
 
 
-void ExtrToSIT::SelectBestCandidateLimited(EVENT::TrackerHitVec &HitsInLayer, const float* &pivot, EVENT::TrackerHit* &BestHit, const FloatVec& covLCIO, double& radius, bool &BestHitFound, double &sigma, int &pointer, int &PossibleHits, float &dU, float &dV, double &DimDist, TrackerHitVec &usedSiHits)
+void ExtrToSIT::SelectBestCandidateLimited(EVENT::TrackerHitVec &HitsInLayer, const float* &pivot, EVENT::TrackerHit* &BestHit, const FloatVec& covLCIO, double& radius, bool &BestHitFound, double &sigma, int &pointer, int &PossibleHits, float &dU, float &dV, double &DimDist, TrackerHitVec& /*usedSiHits*/)
 {
 
   BestHitFound = false ;
@@ -825,11 +824,8 @@ LCCollection* ExtrToSIT::GetCollection( LCEvent * evt, std::string colName ){
   
   LCCollection* col = NULL;
   
-  int nElements = 0;
-  
   try{
     col = evt->getCollection( colName.c_str() ) ;
-    nElements = col->getNumberOfElements()  ;
     streamlog_out( DEBUG3 ) << " --> " << colName.c_str() << " track collection found in event = " << col << " number of elements " << col->getNumberOfElements() << std::endl;
   }
   catch(DataNotAvailableException &e){

--- a/source/Refitting/src/ExtrToSIT.cc
+++ b/source/Refitting/src/ExtrToSIT.cc
@@ -790,6 +790,7 @@ void ExtrToSIT::SelectBestCandidateLimited(EVENT::TrackerHitVec &HitsInLayer, co
 
     streamlog_out(DEBUG1) << " Checking candidate hit " <<  CandidateHit << std::endl ;
 
+    //FIXME: is this intentional???? This means the pointer reference will never be changed!
     int pointer = 0;
     
     double distZ = 0 ;   double distRphi = 0 ;

--- a/source/Refitting/src/ExtrToSIT.cc
+++ b/source/Refitting/src/ExtrToSIT.cc
@@ -789,9 +789,6 @@ void ExtrToSIT::SelectBestCandidateLimited(EVENT::TrackerHitVec &HitsInLayer, co
     EVENT::TrackerHit *CandidateHit = HitsInLayer.at(i);
 
     streamlog_out(DEBUG1) << " Checking candidate hit " <<  CandidateHit << std::endl ;
-
-    //FIXME: is this intentional???? This means the pointer reference will never be changed!
-    int pointer = 0;
     
     double distZ = 0 ;   double distRphi = 0 ;
     

--- a/source/Refitting/src/ExtrToTracker.cc
+++ b/source/Refitting/src/ExtrToTracker.cc
@@ -392,13 +392,13 @@ void ExtrToTracker::processEvent( LCEvent * evt ) {
 
 	  IMPL::TrackImpl* lcio_trk = new IMPL::TrackImpl();
 
-	  IMarlinTrack* marlinTrk0 = 0 ;
+	  IMarlinTrack* marlinTrk = 0 ;
 
 	  if( ! _performFinalRefit ) {
 
 	    //fg: ------ here we just create a final LCIO track from the extrapolation :
 	    
-	    marlinTrk0 = marlin_trk ;
+	    marlinTrk = marlin_trk ;
 	    
 	    bool fit_direction = IMarlinTrack::forward ;
 	    int return_code =  finaliseLCIOTrack( marlin_trk, lcio_trk, trkHits,  fit_direction ) ;
@@ -429,10 +429,7 @@ void ExtrToTracker::processEvent( LCEvent * evt ) {
 	    bool fit_backwards = IMarlinTrack::backward;
 	    //bool fit_forwards = IMarlinTrack::forward;
 
-	    //APS: is this really supposed to create a new pointer, or use the
-	    //pointer marlinTrk0 from before, or overwrite marlinTrk0 if this
-	    //was successful?
-	    MarlinTrk::IMarlinTrack* marlinTrk = _trksystem->createTrack();		
+	    marlinTrk = _trksystem->createTrack();
 
 
 	    std::vector<EVENT::TrackerHit* > vec_hits;
@@ -496,16 +493,16 @@ void ExtrToTracker::processEvent( LCEvent * evt ) {
 	  
 	  // remember the hits are ordered in the order in which they were fitted
 	  
-	  marlinTrk0->getHitsInFit(hits_in_fit);
+	  marlinTrk->getHitsInFit(hits_in_fit);
 	  
 	  if( hits_in_fit.size() < 3 ) {
 	    streamlog_out(DEBUG3) << "RefitProcessor: Less than 3 hits in fit: Track Discarded. Number of hits =  " << trkHits.size() << std::endl;
-	    delete marlinTrk0 ;
+	    delete marlinTrk ;
 	    delete lcio_trk;
 	    continue ; 
 	  }
 	    
-	  marlinTrk0->getOutliers(outliers);
+	  marlinTrk->getOutliers(outliers);
 	  
 	  std::vector<TrackerHit*> all_hits;
 	  all_hits.reserve( hits_in_fit.size() + outliers.size() );
@@ -539,7 +536,7 @@ void ExtrToTracker::processEvent( LCEvent * evt ) {
 	  trackVec->addElement( lcio_trk );
 	    
 
-	  if( _performFinalRefit ) delete marlinTrk0 ;
+	  if( _performFinalRefit ) delete marlinTrk ;
 
 	}  // good fit status
       } // good initialisation status

--- a/source/Refitting/src/ExtrToTracker.cc
+++ b/source/Refitting/src/ExtrToTracker.cc
@@ -392,13 +392,13 @@ void ExtrToTracker::processEvent( LCEvent * evt ) {
 
 	  IMPL::TrackImpl* lcio_trk = new IMPL::TrackImpl();
 
-	  IMarlinTrack* marlinTrk = 0 ;
+	  IMarlinTrack* marlinTrk0 = 0 ;
 
 	  if( ! _performFinalRefit ) {
 
 	    //fg: ------ here we just create a final LCIO track from the extrapolation :
 	    
-	    marlinTrk = marlin_trk ;
+	    marlinTrk0 = marlin_trk ;
 	    
 	    bool fit_direction = IMarlinTrack::forward ;
 	    int return_code =  finaliseLCIOTrack( marlin_trk, lcio_trk, trkHits,  fit_direction ) ;
@@ -428,6 +428,10 @@ void ExtrToTracker::processEvent( LCEvent * evt ) {
 
 	    bool fit_backwards = IMarlinTrack::backward;
 	    //bool fit_forwards = IMarlinTrack::forward;
+
+	    //APS: is this really supposed to create a new pointer, or use the
+	    //pointer marlinTrk0 from before, or overwrite marlinTrk0 if this
+	    //was successful?
 	    MarlinTrk::IMarlinTrack* marlinTrk = _trksystem->createTrack();		
 
 
@@ -492,16 +496,16 @@ void ExtrToTracker::processEvent( LCEvent * evt ) {
 	  
 	  // remember the hits are ordered in the order in which they were fitted
 	  
-	  marlinTrk->getHitsInFit(hits_in_fit);
+	  marlinTrk0->getHitsInFit(hits_in_fit);
 	  
 	  if( hits_in_fit.size() < 3 ) {
 	    streamlog_out(DEBUG3) << "RefitProcessor: Less than 3 hits in fit: Track Discarded. Number of hits =  " << trkHits.size() << std::endl;
-	    delete marlinTrk ;
+	    delete marlinTrk0 ;
 	    delete lcio_trk;
 	    continue ; 
 	  }
 	    
-	  marlinTrk->getOutliers(outliers);
+	  marlinTrk0->getOutliers(outliers);
 	  
 	  std::vector<TrackerHit*> all_hits;
 	  all_hits.reserve( hits_in_fit.size() + outliers.size() );
@@ -535,7 +539,7 @@ void ExtrToTracker::processEvent( LCEvent * evt ) {
 	  trackVec->addElement( lcio_trk );
 	    
 
-	  if( _performFinalRefit ) delete marlinTrk ;
+	  if( _performFinalRefit ) delete marlinTrk0 ;
 
 	}  // good fit status
       } // good initialisation status

--- a/source/Refitting/src/ExtrToTracker.cc
+++ b/source/Refitting/src/ExtrToTracker.cc
@@ -200,7 +200,7 @@ void ExtrToTracker::init() {
 }
 
 
-void ExtrToTracker::processRunHeader( LCRunHeader* run) { 
+void ExtrToTracker::processRunHeader( LCRunHeader* ) {
   
   ++_n_run ;
 } 
@@ -591,7 +591,7 @@ void ExtrToTracker::processEvent( LCEvent * evt ) {
 
 
 
-void ExtrToTracker::check( LCEvent * evt ) { 
+void ExtrToTracker::check( LCEvent* ) {
   // nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 
@@ -620,12 +620,9 @@ void ExtrToTracker::end(){
 LCCollection* ExtrToTracker::GetCollection( LCEvent * evt, std::string colName ){
   
   LCCollection* col = NULL;
-  
-  // int nElements = 0;
-  
+
   try{
     col = evt->getCollection( colName.c_str() ) ;
-    //int nElements = col->getNumberOfElements()  ;
     streamlog_out( DEBUG3 ) << " --> " << colName.c_str() << " track collection found in event = " << col << " number of elements " << col->getNumberOfElements() << std::endl;
   }
   catch(DataNotAvailableException &e){

--- a/source/Refitting/src/FPCCDFullLDCTracking_MarlinTrk.cc
+++ b/source/Refitting/src/FPCCDFullLDCTracking_MarlinTrk.cc
@@ -1625,13 +1625,13 @@ void FPCCDFullLDCTracking_MarlinTrk::prepareVectors(LCEvent * event ) {
       trackExt->setD0(tpcTrack->getD0());
       trackExt->setZ0(tpcTrack->getZ0());
       float cov[15];
-      float param[5];
       //      float reso[4];
-      param[0] = tpcTrack->getOmega();
-      param[1] = tpcTrack->getTanLambda();
-      param[2] = tpcTrack->getPhi();
-      param[3] = tpcTrack->getD0();
-      param[4] = tpcTrack->getZ0();
+      // float param[5];
+      // param[0] = tpcTrack->getOmega();
+      // param[1] = tpcTrack->getTanLambda();
+      // param[2] = tpcTrack->getPhi();
+      // param[3] = tpcTrack->getD0();
+      // param[4] = tpcTrack->getZ0();
       
       
       const FloatVec Cov = tpcTrack->getCovMatrix();
@@ -1697,13 +1697,12 @@ void FPCCDFullLDCTracking_MarlinTrk::prepareVectors(LCEvent * event ) {
       trackExt->setD0(siTrack->getD0());
       trackExt->setZ0(siTrack->getZ0());
       float cov[15];
-      float param[5];
-      
-      param[0] = siTrack->getOmega();
-      param[1] = siTrack->getTanLambda();
-      param[2] = siTrack->getPhi();
-      param[3] = siTrack->getD0();
-      param[4] = siTrack->getZ0();      
+      // float param[5];
+      // param[0] = siTrack->getOmega();
+      // param[1] = siTrack->getTanLambda();
+      // param[2] = siTrack->getPhi();
+      // param[3] = siTrack->getD0();
+      // param[4] = siTrack->getZ0();
       
       
       
@@ -3199,10 +3198,10 @@ void FPCCDFullLDCTracking_MarlinTrk::CheckTracks() {
         
         HelixClass helix;
         helix.Initialize_Canonical(phi,d0,z0,omega,tanL,_bField);
-        float mom[3];
-        mom[0]  = helix.getMomentum()[0];
-        mom[1]  = helix.getMomentum()[1];
-        mom[2]  = helix.getMomentum()[2];
+        // float mom[3];
+        // mom[0]  = helix.getMomentum()[0];
+        // mom[1]  = helix.getMomentum()[1];
+        // mom[2]  = helix.getMomentum()[2];
         // float p = sqrt(mom[0]*mom[0]+mom[1]*mom[1]+mom[2]*mom[2]);
         // float chi2Sig =  (combinedTrack->getChi2() - combinedTrack->getNDF());
         // chi2Sig = chi2Sig/sqrt(combinedTrack->getNDF()*2);
@@ -3253,7 +3252,7 @@ void FPCCDFullLDCTracking_MarlinTrk::CheckTracks() {
 
 
 float FPCCDFullLDCTracking_MarlinTrk::CompareTrkII(TrackExtended * first, TrackExtended * second, 
-                                              float d0Cut, float z0Cut,int iopt,float & Angle) {
+						   float d0Cut, float z0Cut,int /*iopt*/,float & Angle) {
   
   
   float result = 1.0e+20;
@@ -3310,7 +3309,7 @@ float FPCCDFullLDCTracking_MarlinTrk::CompareTrkII(TrackExtended * first, TrackE
  */
 
 float FPCCDFullLDCTracking_MarlinTrk::CompareTrkIII(TrackExtended * first, TrackExtended * second, 
-                                               float d0Cut, float z0Cut,int iopt, float & AngleSignificance) {
+						    float d0Cut, float z0Cut,int /*iopt*/, float & AngleSignificance) {
   
   
   float result = 1.0e+20;
@@ -4245,10 +4244,10 @@ void FPCCDFullLDCTracking_MarlinTrk::AssignOuterHitsToTracks(TrackerHitExtendedV
           }
           
           const gear::Vector3D point(0.,0.,0.); // nominal IP
-          int return_code = 0;
           
           TrackStateImpl trkState ;
-          return_code = marlin_trk->propagate(point, trkState, chi2_D, ndf ) ;
+          // int return_code =
+          marlin_trk->propagate(point, trkState, chi2_D, ndf ) ;
           
           delete marlin_trk ;
           
@@ -4785,10 +4784,10 @@ void FPCCDFullLDCTracking_MarlinTrk::AssignSiHitsToTracks(TrackerHitExtendedVec 
         }
                 
         const gear::Vector3D point(0.,0.,0.); // nominal IP
-        int return_code = 0;
         
         TrackStateImpl trkState ;
-        return_code = marlin_trk->propagate(point, trkState, chi2_D, ndf ) ;
+        // int return_code =
+        marlin_trk->propagate(point, trkState, chi2_D, ndf ) ;
         
         delete marlin_trk ;
         
@@ -5415,7 +5414,7 @@ bool FPCCDFullLDCTracking_MarlinTrk::VetoMerge(TrackExtended* firstTrackExt, Tra
 }
 
 
-void FPCCDFullLDCTracking_MarlinTrk::check(LCEvent * evt) { }
+void FPCCDFullLDCTracking_MarlinTrk::check(LCEvent* ) { }
 
 void FPCCDFullLDCTracking_MarlinTrk::end() { 
   
@@ -5661,11 +5660,8 @@ LCCollection* FPCCDFullLDCTracking_MarlinTrk::GetCollection(  LCEvent * evt, std
 
   LCCollection* col = NULL;
 
-  int nElements = 0;
-
   try {
     col = evt->getCollection( colName.c_str() ) ;
-    nElements = col->getNumberOfElements()  ;
     streamlog_out( DEBUG4 ) << " --> " << colName.c_str() << " collection found, number of elements = " << col->getNumberOfElements() << std::endl;
   }
   catch(DataNotAvailableException &e) {

--- a/source/Refitting/src/FPCCDSiliconTracking_MarlinTrk.cc
+++ b/source/Refitting/src/FPCCDSiliconTracking_MarlinTrk.cc
@@ -650,7 +650,7 @@ void FPCCDSiliconTracking_MarlinTrk::init() {
 }
 
 
-void FPCCDSiliconTracking_MarlinTrk::processRunHeader( LCRunHeader* run) { 
+void FPCCDSiliconTracking_MarlinTrk::processRunHeader( LCRunHeader* ) {
 
   _nRun++ ;
   _nEvt = 0;
@@ -1335,7 +1335,7 @@ int FPCCDSiliconTracking_MarlinTrk::InitialiseVTX(LCEvent * evt) {
 
 }
 
-void FPCCDSiliconTracking_MarlinTrk::check(LCEvent * evt) { 
+void FPCCDSiliconTracking_MarlinTrk::check(LCEvent* ) {
 
 }
 
@@ -1750,9 +1750,9 @@ TrackExtended * FPCCDSiliconTracking_MarlinTrk::TestTriplet(TrackerHitExtended *
 
 
 
-int FPCCDSiliconTracking_MarlinTrk::BuildTrack_KalFit(TrackerHitExtended * outerHit, 
-    TrackerHitExtended * middleHit,
-    TrackerHitExtended * innerHit,
+int FPCCDSiliconTracking_MarlinTrk::BuildTrack_KalFit(TrackerHitExtended * /*outerHit*/,
+						      TrackerHitExtended * /*middleHit*/,
+						      TrackerHitExtended * /*innerHit*/,
     HelixClass_double & helix,
     int innerLayer,
     TrackExtended * trackAR) {
@@ -2270,7 +2270,7 @@ void FPCCDSiliconTracking_MarlinTrk::CreateTrack(TrackExtended * trackAR ) {
       float * ph = new float[nTotHits];
       float par[5];
       float epar[15];
-      float refPoint[3] = {0.,0.,0.};
+      //float refPoint[3] = {0.,0.,0.};
       for (int ih=0;ih<nHits;++ih) {
         TrackerHit * trkHit = hitVec[ih]->getTrackerHit();
         float rR = hitVec[ih]->getResolutionRPhi();
@@ -2317,15 +2317,15 @@ void FPCCDSiliconTracking_MarlinTrk::CreateTrack(TrackExtended * trackAR ) {
       for (int iparam=0;iparam<15;++iparam)
         eparmin[iparam] = epar[iparam];      
 
-      float refPointMin[3];
-      for (int ipp=0;ipp<3;++ipp)
-        refPointMin[ipp] = refPoint[ipp];
+      // float refPointMin[3];
+      // for (int ipp=0;ipp<3;++ipp)
+      //   refPointMin[ipp] = refPoint[ipp];
 
       float chi2Min = chi2RPhi*_chi2WRPhiSeptet+chi2Z*_chi2WZSeptet;
       chi2Min = chi2Min/float(ndf);
 
-      float chi2MinRPhi = chi2RPhi;
-      float chi2MinZ = chi2Z;
+      //float chi2MinRPhi = chi2RPhi;
+      //float chi2MinZ = chi2Z;
 
 
       int iBad = -1;
@@ -2361,8 +2361,8 @@ void FPCCDSiliconTracking_MarlinTrk::CreateTrack(TrackExtended * trackAR ) {
           if (chi2Cur < chi2Min && std::isnormal(chi2Min) == 1 && chi2Min > 0) {
             //Mori added new requirement that chi2Min be normal value on September 1, 2013.
             chi2Min = chi2Cur;
-            chi2MinRPhi = chi2RPhi;
-            chi2MinZ = chi2Z;
+            //chi2MinRPhi = chi2RPhi;
+            //chi2MinZ = chi2Z;
             omega = par[0];
             tanlambda = par[1];
             phi0 = par[2];
@@ -2370,8 +2370,8 @@ void FPCCDSiliconTracking_MarlinTrk::CreateTrack(TrackExtended * trackAR ) {
             z0 = par[4];
             for (int iparam=0;iparam<15;++iparam)
               eparmin[iparam] = epar[iparam];
-            for (int ipp=0;ipp<3;++ipp)
-              refPointMin[ipp] = refPoint[ipp];
+            // for (int ipp=0;ipp<3;++ipp)
+            //   refPointMin[ipp] = refPoint[ipp];
             iBad = i;
           }
         }
@@ -3290,7 +3290,7 @@ int FPCCDSiliconTracking_MarlinTrk::AttachHitToTrack(TrackExtended * trackAR, Tr
 
 }
 
-void FPCCDSiliconTracking_MarlinTrk::FinalRefit(LCCollectionVec* trk_col, LCCollectionVec* rel_col) {
+void FPCCDSiliconTracking_MarlinTrk::FinalRefit(LCCollectionVec* trk_col, LCCollectionVec* /*rel_col*/) {
 
   int nTracks = int(_trackImplVec.size());
 
@@ -3387,15 +3387,19 @@ void FPCCDSiliconTracking_MarlinTrk::FinalRefit(LCCollectionVec* trk_col, LCColl
 
               if (det == lcio::ILDDetID::FTD) {
 
-                double time = helix->getPointInZ(xP[2],Pos,Point);
-                time = helix->getPointInZ(xPS[2],Pos,PointS);
+                // double time =
+		 helix->getPointInZ(xP[2],Pos,Point);
+                // double time =
+		 helix->getPointInZ(xPS[2],Pos,PointS);
 
               } else {
 
                 double RAD = sqrt(xP[0]*xP[0]+xP[1]*xP[1]);
                 double RADS = sqrt(xPS[0]*xPS[0]+xPS[1]*xPS[1]);
-                double time = helix->getPointOnCircle(RAD,Pos,Point);
-                time = helix->getPointOnCircle(RADS,Pos,PointS);
+                // double time =
+		 helix->getPointOnCircle(RAD,Pos,Point);
+                // double time =
+		 helix->getPointOnCircle(RADS,Pos,PointS);
 
               }
 
@@ -3795,11 +3799,9 @@ LCCollection* FPCCDSiliconTracking_MarlinTrk::GetCollection(  LCEvent * evt, std
 
   LCCollection* col = NULL;
 
-  int nElements = 0;
 
   try {
     col = evt->getCollection( colName.c_str() ) ;
-    nElements = col->getNumberOfElements()  ;
     streamlog_out( DEBUG4 ) << " --> " << colName.c_str() << " collection found, number of elements = " << col->getNumberOfElements() << std::endl;
   }
   catch(DataNotAvailableException &e) {
@@ -4136,7 +4138,7 @@ void FPCCDSiliconTracking_MarlinTrk::calcTrackParameterOfMCP(MCParticle* pmcp, d
 }
 
 
-int FPCCDSiliconTracking_MarlinTrk::CheckTiltOf2Clusters(TrackerHit* A, TrackerHit* B, int level){
+int FPCCDSiliconTracking_MarlinTrk::CheckTiltOf2Clusters(TrackerHit* A, TrackerHit* B, int /*level*/){
   //level is set for the future where users choose the level of requirement hardness.
   //For now, this level is not alive.
 

--- a/source/Refitting/src/FullLDCTracking_MarlinTrk.cc
+++ b/source/Refitting/src/FullLDCTracking_MarlinTrk.cc
@@ -1475,13 +1475,13 @@ void FullLDCTracking_MarlinTrk::prepareVectors(LCEvent * event ) {
       trackExt->setD0(tpcTrack->getD0());
       trackExt->setZ0(tpcTrack->getZ0());
       float cov[15];
-      float param[5];
       //      float reso[4];
-      param[0] = tpcTrack->getOmega();
-      param[1] = tpcTrack->getTanLambda();
-      param[2] = tpcTrack->getPhi();
-      param[3] = tpcTrack->getD0();
-      param[4] = tpcTrack->getZ0();
+      // float param[5];
+      // param[0] = tpcTrack->getOmega();
+      // param[1] = tpcTrack->getTanLambda();
+      // param[2] = tpcTrack->getPhi();
+      // param[3] = tpcTrack->getD0();
+      // param[4] = tpcTrack->getZ0();
       
       
       const FloatVec Cov = tpcTrack->getCovMatrix();
@@ -1540,13 +1540,12 @@ void FullLDCTracking_MarlinTrk::prepareVectors(LCEvent * event ) {
       trackExt->setD0(siTrack->getD0());
       trackExt->setZ0(siTrack->getZ0());
       float cov[15];
-      float param[5];
-      
-      param[0] = siTrack->getOmega();
-      param[1] = siTrack->getTanLambda();
-      param[2] = siTrack->getPhi();
-      param[3] = siTrack->getD0();
-      param[4] = siTrack->getZ0();      
+      // float param[5];
+      // param[0] = siTrack->getOmega();
+      // param[1] = siTrack->getTanLambda();
+      // param[2] = siTrack->getPhi();
+      // param[3] = siTrack->getD0();
+      // param[4] = siTrack->getZ0();
       
       
       
@@ -3045,10 +3044,10 @@ void FullLDCTracking_MarlinTrk::CheckTracks() {
         
         HelixClass helix;
         helix.Initialize_Canonical(phi,d0,z0,omega,tanL,_bField);
-        float mom[3];
-        mom[0]  = helix.getMomentum()[0];
-        mom[1]  = helix.getMomentum()[1];
-        mom[2]  = helix.getMomentum()[2];
+        // float mom[3];
+        // mom[0]  = helix.getMomentum()[0];
+        // mom[1]  = helix.getMomentum()[1];
+        // mom[2]  = helix.getMomentum()[2];
         // float p = sqrt(mom[0]*mom[0]+mom[1]*mom[1]+mom[2]*mom[2]);
         // float chi2Sig =  (combinedTrack->getChi2() - combinedTrack->getNDF());
         // chi2Sig = chi2Sig/sqrt(combinedTrack->getNDF()*2);
@@ -3099,7 +3098,7 @@ void FullLDCTracking_MarlinTrk::CheckTracks() {
 
 
 float FullLDCTracking_MarlinTrk::CompareTrkII(TrackExtended * first, TrackExtended * second, 
-                                              float d0Cut, float z0Cut,int iopt,float & Angle) {
+                                              float d0Cut, float z0Cut,int /*iopt*/,float & Angle) {
   
   
   float result = 1.0e+20;
@@ -3156,7 +3155,7 @@ float FullLDCTracking_MarlinTrk::CompareTrkII(TrackExtended * first, TrackExtend
  */
 
 float FullLDCTracking_MarlinTrk::CompareTrkIII(TrackExtended * first, TrackExtended * second, 
-                                               float d0Cut, float z0Cut,int iopt, float & AngleSignificance) {
+                                               float d0Cut, float z0Cut,int /*iopt*/, float & AngleSignificance) {
   
   
   float result = 1.0e+20;
@@ -4091,10 +4090,9 @@ void FullLDCTracking_MarlinTrk::AssignOuterHitsToTracks(TrackerHitExtendedVec hi
           }
           
           const gear::Vector3D point(0.,0.,0.); // nominal IP
-          int return_code = 0;
-          
           TrackStateImpl trkState ;
-          return_code = marlin_trk->propagate(point, trkState, chi2_D, ndf ) ;
+          // int return_code =
+	   marlin_trk->propagate(point, trkState, chi2_D, ndf ) ;
           
           delete marlin_trk ;
           
@@ -4631,10 +4629,10 @@ void FullLDCTracking_MarlinTrk::AssignSiHitsToTracks(TrackerHitExtendedVec hitVe
         }
                 
         const gear::Vector3D point(0.,0.,0.); // nominal IP
-        int return_code = 0;
         
         TrackStateImpl trkState ;
-        return_code = marlin_trk->propagate(point, trkState, chi2_D, ndf ) ;
+        // int return_code =
+	 marlin_trk->propagate(point, trkState, chi2_D, ndf ) ;
         
         delete marlin_trk ;
         
@@ -5261,7 +5259,7 @@ bool FullLDCTracking_MarlinTrk::VetoMerge(TrackExtended* firstTrackExt, TrackExt
 }
 
 
-void FullLDCTracking_MarlinTrk::check(LCEvent * evt) { }
+void FullLDCTracking_MarlinTrk::check( LCEvent* ) { }
 
 void FullLDCTracking_MarlinTrk::end() { 
   

--- a/source/Refitting/src/GetPurity.h
+++ b/source/Refitting/src/GetPurity.h
@@ -57,9 +57,9 @@ class GetPurityUtil{
          LCObject* trk = dynamic_cast<LCObject*>(tvec[i]);
          const LCObjectVec* lcoVec = NULL;
          int navsize = navec.size();
-         for(int i = 0; i < navsize; i++){
-            if(navec[i] != NULL){
-               lcoVec = &navec[i]->getRelatedToObjects(trk);//見つからない場合はNULLを返すわけじゃないので、sizeが0かどうかで判定する。
+         for(int j = 0; i < navsize; j++){
+            if(navec[j] != NULL){
+               lcoVec = &navec[j]->getRelatedToObjects(trk);//見つからない場合はNULLを返すわけじゃないので、sizeが0かどうかで判定する。
                if(lcoVec->size() != 0){
                   break;
                }

--- a/source/Refitting/src/RefitProcessor.cc
+++ b/source/Refitting/src/RefitProcessor.cc
@@ -173,7 +173,7 @@ void RefitProcessor::init() {
   
 }
 
-void RefitProcessor::processRunHeader( LCRunHeader* run) { 
+void RefitProcessor::processRunHeader( LCRunHeader* ) {
   
   ++_n_run ;
 } 
@@ -422,7 +422,7 @@ void RefitProcessor::processEvent( LCEvent * evt ) {
 
 
 
-void RefitProcessor::check( LCEvent * evt ) { 
+void RefitProcessor::check( LCEvent * ) {
   // nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 
@@ -439,11 +439,9 @@ LCCollection* RefitProcessor::GetCollection( LCEvent * evt, std::string colName 
   
   LCCollection* col = NULL;
   
-  int nElements = 0;
   
   try{
     col = evt->getCollection( colName.c_str() ) ;
-    nElements = col->getNumberOfElements()  ;
     streamlog_out( DEBUG4 ) << " --> " << colName.c_str() << " track collection found in event = " << col << " number of elements " << col->getNumberOfElements() << std::endl;
   }
   catch(DataNotAvailableException &e){

--- a/source/Refitting/src/SiliconTracking_MarlinTrk.cc
+++ b/source/Refitting/src/SiliconTracking_MarlinTrk.cc
@@ -683,7 +683,7 @@ void SiliconTracking_MarlinTrk::init() {
 }
 
 
-void SiliconTracking_MarlinTrk::processRunHeader( LCRunHeader* run) { 
+void SiliconTracking_MarlinTrk::processRunHeader( LCRunHeader* ) {
   
   _nRun++ ;
   _nEvt = 0;
@@ -1362,7 +1362,7 @@ int SiliconTracking_MarlinTrk::InitialiseVTX(LCEvent * evt) {
   
 }
 
-void SiliconTracking_MarlinTrk::check(LCEvent * evt) { 
+void SiliconTracking_MarlinTrk::check( LCEvent* ) {
   
 }
 
@@ -1907,9 +1907,9 @@ TrackExtended * SiliconTracking_MarlinTrk::TestTriplet(TrackerHitExtended * oute
   
 }
 
-int SiliconTracking_MarlinTrk::BuildTrack(TrackerHitExtended * outerHit, 
-                                          TrackerHitExtended * middleHit,
-                                          TrackerHitExtended * innerHit,
+int SiliconTracking_MarlinTrk::BuildTrack(TrackerHitExtended * /*outerHit*/,
+                                          TrackerHitExtended * /*middleHit*/,
+                                          TrackerHitExtended * /*innerHit*/,
                                           HelixClass & helix,
                                           int innerLayer,
                                           int iPhiLow, int iPhiUp,
@@ -2156,7 +2156,7 @@ void SiliconTracking_MarlinTrk::CreateTrack(TrackExtended * trackAR ) {
       float * ph = new float[nTotHits];
       float par[5];
       float epar[15];
-      float refPoint[3] = {0.,0.,0.};
+      //float refPoint[3] = {0.,0.,0.};
       for (int ih=0;ih<nHits;++ih) {
         TrackerHit * trkHit = hitVec[ih]->getTrackerHit();
         float rR = hitVec[ih]->getResolutionRPhi();
@@ -2203,15 +2203,15 @@ void SiliconTracking_MarlinTrk::CreateTrack(TrackExtended * trackAR ) {
       for (int iparam=0;iparam<15;++iparam)
         eparmin[iparam] = epar[iparam];      
       
-      float refPointMin[3];
-      for (int ipp=0;ipp<3;++ipp)
-        refPointMin[ipp] = refPoint[ipp];
+      // float refPointMin[3];
+      // for (int ipp=0;ipp<3;++ipp)
+      //   refPointMin[ipp] = refPoint[ipp];
       
       float chi2Min = chi2RPhi*_chi2WRPhiSeptet+chi2Z*_chi2WZSeptet;
       chi2Min = chi2Min/float(ndf);
       
-      float chi2MinRPhi = chi2RPhi;
-      float chi2MinZ = chi2Z;
+      //float chi2MinRPhi = chi2RPhi;
+      //float chi2MinZ = chi2Z;
       
       int iBad = -1;
       if (chi2Min < _chi2FitCut) {
@@ -2244,8 +2244,8 @@ void SiliconTracking_MarlinTrk::CreateTrack(TrackExtended * trackAR ) {
           
           if (chi2Cur < chi2Min) {
             chi2Min = chi2Cur;
-            chi2MinRPhi = chi2RPhi;
-            chi2MinZ = chi2Z;
+            //chi2MinRPhi = chi2RPhi;
+            //chi2MinZ = chi2Z;
             omega = par[0];
             tanlambda = par[1];
             phi0 = par[2];
@@ -2253,8 +2253,8 @@ void SiliconTracking_MarlinTrk::CreateTrack(TrackExtended * trackAR ) {
             z0 = par[4];
             for (int iparam=0;iparam<15;++iparam)
               eparmin[iparam] = epar[iparam];
-            for (int ipp=0;ipp<3;++ipp)
-              refPointMin[ipp] = refPoint[ipp];
+            // for (int ipp=0;ipp<3;++ipp)
+            //   refPointMin[ipp] = refPoint[ipp];
             iBad = i;
           }
         }
@@ -3025,7 +3025,7 @@ int SiliconTracking_MarlinTrk::AttachHitToTrack(TrackExtended * trackAR, Tracker
   
 }
 
-void SiliconTracking_MarlinTrk::FinalRefit(LCCollectionVec* trk_col, LCCollectionVec* rel_col) {
+void SiliconTracking_MarlinTrk::FinalRefit(LCCollectionVec* trk_col, LCCollectionVec* /*rel_col*/) {
   
   int nTracks = int(_trackImplVec.size());
   
@@ -3122,15 +3122,19 @@ void SiliconTracking_MarlinTrk::FinalRefit(LCCollectionVec* trk_col, LCCollectio
               
               if (det == lcio::ILDDetID::FTD) {
 
-                float time = helix->getPointInZ(xP[2],Pos,Point);
-                time = helix->getPointInZ(xPS[2],Pos,PointS);
+                // float time =
+		  helix->getPointInZ(xP[2],Pos,Point);
+                // float time =
+		  helix->getPointInZ(xPS[2],Pos,PointS);
 
               } else {
 
                 float RAD = sqrt(xP[0]*xP[0]+xP[1]*xP[1]);
                 float RADS = sqrt(xPS[0]*xPS[0]+xPS[1]*xPS[1]);
-                float time = helix->getPointOnCircle(RAD,Pos,Point);
-                time = helix->getPointOnCircle(RADS,Pos,PointS);
+                // float time =
+		  helix->getPointOnCircle(RAD,Pos,Point);
+                // float time =
+		  helix->getPointOnCircle(RADS,Pos,PointS);
 
               }
               
@@ -3607,11 +3611,8 @@ LCCollection* SiliconTracking_MarlinTrk::GetCollection(  LCEvent * evt, std::str
   
   LCCollection* col = NULL;
   
-  int nElements = 0;
-  
   try {
     col = evt->getCollection( colName.c_str() ) ;
-    nElements = col->getNumberOfElements()  ;
     streamlog_out( DEBUG4 ) << " --> " << colName.c_str() << " collection found, number of elements = " << col->getNumberOfElements() << std::endl;
   }
   catch(DataNotAvailableException &e) {

--- a/source/Refitting/src/TrackSubsetProcessor.cc
+++ b/source/Refitting/src/TrackSubsetProcessor.cc
@@ -173,7 +173,7 @@ void TrackSubsetProcessor::init() {
 }
 
 
-void TrackSubsetProcessor::processRunHeader( LCRunHeader* run) { 
+void TrackSubsetProcessor::processRunHeader( LCRunHeader* ) {
 
     _nRun++ ;
 } 
@@ -541,7 +541,7 @@ void TrackSubsetProcessor::removeShortTracks( std::vector< EVENT::Track*>& track
 }
 
 
-void TrackSubsetProcessor::check( LCEvent * evt ) { 
+void TrackSubsetProcessor::check( LCEvent* ) {
     // nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 

--- a/source/Refitting/src/TruthTrackFinder.cc
+++ b/source/Refitting/src/TruthTrackFinder.cc
@@ -186,7 +186,7 @@ void TruthTrackFinder::init() {
 }
 
 
-void TruthTrackFinder::processRunHeader( LCRunHeader* run) {
+void TruthTrackFinder::processRunHeader( LCRunHeader* ) {
 	m_runNumber++ ;
 }
 
@@ -270,7 +270,7 @@ void TruthTrackFinder::processEvent( LCEvent* evt ) {
   for(int itP=0;itP<nParticles;itP++){
 		
     // Get the particle
-    MCParticle* mcParticle = dynamic_cast<MCParticle*>( particleCollection->getElementAt(itP) ) ;
+    MCParticle* mcParticle = static_cast<MCParticle*>( particleCollection->getElementAt(itP) ) ;
     
     // Get the vector of hits from the container
     if(particleHits.count(mcParticle) == 0) continue;
@@ -357,7 +357,7 @@ void TruthTrackFinder::processEvent( LCEvent* evt ) {
         std::sort(trackfitHits.begin(),trackfitHits.end(),sort_by_z);        
 
         // If fit with hits ordered by radius has failed, the track is probably a 'spiral' track. 
-        // Fitting 'backward' is very difficult for spiral track, so the default directiin here is set as 'forward'
+        // Fitting 'backward' is very difficult for spiral track, so the default direction here is set as 'forward'
         fitError = MarlinTrk::createFinalisedLCIOTrack(marlinTrackZSort, trackfitHits, track,  MarlinTrk::IMarlinTrack::forward, trkState, m_magneticField, m_maxChi2perHit);
       }
 
@@ -445,7 +445,7 @@ void TruthTrackFinder::processEvent( LCEvent* evt ) {
 	
 }
 
-void TruthTrackFinder::check( LCEvent * evt ) {
+void TruthTrackFinder::check( LCEvent* ) {
 	// nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 

--- a/source/Refitting/src/TruthTracker.cc
+++ b/source/Refitting/src/TruthTracker.cc
@@ -311,7 +311,7 @@ void TruthTracker::init() {
   
 }
 
-void TruthTracker::processRunHeader( LCRunHeader* run) { 
+void TruthTracker::processRunHeader( LCRunHeader* ) {
   
   ++_n_run ;
 } 
@@ -601,7 +601,7 @@ void TruthTracker::processEvent( LCEvent * evt ) {
 
 
 
-void TruthTracker::check( LCEvent * evt ) { 
+void TruthTracker::check( LCEvent* ) {
   // nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 
@@ -919,7 +919,7 @@ void TruthTracker::createTrack_iterative( MCParticle* mcp, UTIL::BitField64& cel
   int layer  = 9 ;
   int size   = 3 ;
   int marker = 1 ;
-  int ml     = 0 ;
+  //int ml     = 0 ;
   float helix_max_r = 0;
   float helix_max_z = 0;
   int color = 0;
@@ -2062,11 +2062,8 @@ LCCollection* TruthTracker::GetCollection(  LCEvent * evt, std::string colName )
   
   LCCollection* col = NULL;
   
-  int nElements = 0;
-  
   try {
     col = evt->getCollection( colName.c_str() ) ;
-    nElements = col->getNumberOfElements()  ;
     streamlog_out( DEBUG4 ) << " --> " << colName.c_str() << " collection found, number of elements = " << col->getNumberOfElements() << std::endl;
   }
   catch(DataNotAvailableException &e) {

--- a/source/Utils/src/CalcTrackerHitResiduals.cc
+++ b/source/Utils/src/CalcTrackerHitResiduals.cc
@@ -130,7 +130,7 @@ void CalcTrackerHitResiduals::init() {
   
 }
 
-void CalcTrackerHitResiduals::processRunHeader( LCRunHeader* run) { 
+void CalcTrackerHitResiduals::processRunHeader( LCRunHeader* ) {
   
   ++_n_run ;
 } 
@@ -369,7 +369,7 @@ void CalcTrackerHitResiduals::processEvent( LCEvent * evt ) {
 
 
 
-void CalcTrackerHitResiduals::check( LCEvent * evt ) { 
+void CalcTrackerHitResiduals::check( LCEvent* ) {
   // nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 
@@ -448,11 +448,8 @@ LCCollection* CalcTrackerHitResiduals::GetCollection(  LCEvent * evt, std::strin
   
   LCCollection* col = NULL;
   
-  int nElements = 0;
-  
   try {
     col = evt->getCollection( colName.c_str() ) ;
-    nElements = col->getNumberOfElements()  ;
     streamlog_out( DEBUG4 ) << " --> " << colName.c_str() << " collection found, number of elements = " << col->getNumberOfElements() << std::endl;
   }
   catch(DataNotAvailableException &e) {

--- a/source/Utils/src/SetTrackerHitExtensions.cc
+++ b/source/Utils/src/SetTrackerHitExtensions.cc
@@ -101,7 +101,7 @@ void SetTrackerHitExtensions::init() {
     
 }
 
-void SetTrackerHitExtensions::processRunHeader( LCRunHeader* run) { 
+void SetTrackerHitExtensions::processRunHeader( LCRunHeader* ) {
   
   ++_n_run ;
 } 
@@ -226,7 +226,7 @@ void SetTrackerHitExtensions::processEvent( LCEvent * evt ) {
 
 
 
-void SetTrackerHitExtensions::check( LCEvent * evt ) { 
+void SetTrackerHitExtensions::check( LCEvent* ) {
   // nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 
@@ -282,11 +282,8 @@ LCCollection* SetTrackerHitExtensions::GetCollection(  LCEvent * evt, std::strin
   
   LCCollection* col = NULL;
   
-  int nElements = 0;
-  
   try {
     col = evt->getCollection( colName.c_str() ) ;
-    nElements = col->getNumberOfElements()  ;
     streamlog_out( DEBUG4 ) << " --> " << colName.c_str() << " collection found, number of elements = " << col->getNumberOfElements() << std::endl;
   }
   catch(DataNotAvailableException &e) {

--- a/source/Utils/src/SplitCollectionByLayer.cc
+++ b/source/Utils/src/SplitCollectionByLayer.cc
@@ -90,7 +90,7 @@ void SplitCollectionByLayer::init() {
 }
 
 
-void SplitCollectionByLayer::processRunHeader( LCRunHeader* run) { 
+void SplitCollectionByLayer::processRunHeader( LCRunHeader* ) {
   
   _nRun++ ;
 } 
@@ -153,9 +153,9 @@ void SplitCollectionByLayer::processEvent( LCEvent * evt ) {
 
   int nHit = col->getNumberOfElements()  ;
   
-  for(int i=0; i< nHit ; i++){
+  for(int iHit=0; iHit< nHit ; iHit++){
       
-    lcio::LCObject* h =  col->getElementAt( i ) ;
+    lcio::LCObject* h =  col->getElementAt( iHit ) ;
 
     long id = -1 ;
 
@@ -183,7 +183,7 @@ void SplitCollectionByLayer::processEvent( LCEvent * evt ) {
 
 
     // check if we have an output collection for this layer
-    for(unsigned i=0, N= _outCols.size() ; i<N ; ++i){
+    for(int i=0, N=_outCols.size() ; i<N ; ++i){
       
       if( ( _outCols[i].layer0 <= layerID )  && ( layerID <= _outCols[i].layer1 ) ){
 
@@ -222,7 +222,7 @@ void SplitCollectionByLayer::processEvent( LCEvent * evt ) {
 
 
 
-void SplitCollectionByLayer::check( LCEvent * evt ) { 
+void SplitCollectionByLayer::check( LCEvent* ) {
   // nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 

--- a/source/Utils/src/SplitCollectionByLayer.cc
+++ b/source/Utils/src/SplitCollectionByLayer.cc
@@ -179,7 +179,7 @@ void SplitCollectionByLayer::processEvent( LCEvent * evt ) {
 
     encoder.setValue( id ) ;
 
-    int layerID = encoder[ layerIndex ] ;
+    unsigned int layerID = encoder[ layerIndex ] ;
 
 
     // check if we have an output collection for this layer

--- a/source/ftf/src/Track.cc
+++ b/source/ftf/src/Track.cc
@@ -1397,7 +1397,7 @@ void Track::fillPrimary (  double &xc, double &yc, double &rc,
 //
 //****************************************************************************
 void Track::fillSecondary ( double &xc, double &yc,
-						   double xPar, double yPar )
+			    double /*xPar*/, double /*yPar*/ )
 {
 	/*--------------------------------------------------------------------------
 	Get angles for initial and final points
@@ -1548,6 +1548,7 @@ int Track::followHitSelection ( Hit* baseHit, Hit* candidateHit ){
 	//
 	double lszChi2 = 0 ;
 	double lchi2 ;
+	//FIXME: slocal might be used uninitialised, what is a reasonable default value?
 	double slocal, deta, dphi ;
 	double dx, dy, dxy, dsz, temp ;
 	//

--- a/source/ftf/src/TrackFinderFTF.cc
+++ b/source/ftf/src/TrackFinderFTF.cc
@@ -295,7 +295,7 @@ void TrackFinderFTF::init() {
   
 }
 
-void TrackFinderFTF::processRunHeader( LCRunHeader* run) { 
+void TrackFinderFTF::processRunHeader( LCRunHeader* ) {
   
   ++_n_run ;
 } 
@@ -512,11 +512,6 @@ void TrackFinderFTF::processEvent( LCEvent * evt ) {
   
   _trackFinder->nHits = counter ;
   
-  int   lastNTracks ;
-  double sectorTime ;
-  //
-  //
-  
   for ( int h = 0 ; h < _trackFinder->nHits ; h++ ) {
     _trackFinder->hit[h].track = 0 ;
   }
@@ -525,11 +520,9 @@ void TrackFinderFTF::processEvent( LCEvent * evt ) {
   _trackFinder->para.eventReset = 1 ;
   _trackFinder->nTracks         = 0 ;
   
-  sectorTime = _trackFinder->process ( ) ;
-  
-  lastNTracks = _trackFinder->nTracks ;
-  
-  
+  // double sectorTime =
+  _trackFinder->process ( ) ;
+
   // print input and output for this event
   _trackFinder->para.print();
   //
@@ -661,7 +654,7 @@ void TrackFinderFTF::processEvent( LCEvent * evt ) {
 
 
 
-void TrackFinderFTF::check( LCEvent * evt ) { 
+void TrackFinderFTF::check( LCEvent* ) {
   // nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 
@@ -685,11 +678,8 @@ LCCollection* TrackFinderFTF::GetCollection( LCEvent * evt, std::string colName 
   
   LCCollection* col = NULL;
   
-  int nElements = 0;
-  
   try{
     col = evt->getCollection( colName.c_str() ) ;
-    nElements = col->getNumberOfElements()  ;
     streamlog_out( DEBUG4 ) << " --> " << colName.c_str() << " track collection found in event = " << col << " number of elements " << col->getNumberOfElements() << std::endl;
   }
   catch(DataNotAvailableException &e){

--- a/source/ftf/src/TrackFindingParameters.cc
+++ b/source/ftf/src/TrackFindingParameters.cc
@@ -84,59 +84,59 @@ void TrackFindingParameters::read ( char* inputFile )
 			continue ;
 		}
 		if ( !strncmp(name,"detaMerge    ",   8) ) {
-			fscanf ( dataFile, "%e", &detaMerge     ) ;
+			fscanf ( dataFile, "%le", &detaMerge     ) ;
 			continue ;
 		}
 		if ( !strncmp(name,"deta         ",   4) ) {
-			fscanf ( dataFile, "%e", &deta          ) ;
+			fscanf ( dataFile, "%le", &deta          ) ;
 			continue ;
 		}  
 		if ( !strncmp(name,"dphiMerge    ",   8) ) {
-			fscanf ( dataFile, "%e", &dphiMerge     ) ;
+			fscanf ( dataFile, "%le", &dphiMerge     ) ;
 			continue ;
 		}
 		if ( !strncmp(name,"dphi         ",   4) ) {
-			fscanf ( dataFile, "%e", &dphi          ) ;
+			fscanf ( dataFile, "%le", &dphi          ) ;
 			continue ;
 		}  
 		if ( !strncmp(name,"etaMinTrack  ",   8) ) {
-			fscanf ( dataFile, "%e", &etaMinTrack   ) ;
+			fscanf ( dataFile, "%le", &etaMinTrack   ) ;
 			continue ;
 		}
 		if ( !strncmp(name,"etaMin",   6) ) {
-			fscanf ( dataFile, "%e", &etaMin        ) ;
+			fscanf ( dataFile, "%le", &etaMin        ) ;
 			continue ;
 		}  
 		if ( !strncmp(name,"etaMaxTrack  ",   8) ) {
-			fscanf ( dataFile, "%e", &etaMaxTrack   ) ;
+			fscanf ( dataFile, "%le", &etaMaxTrack   ) ;
 			continue ;
 		}
 		if ( !strncmp(name,"etaMax       ",   6) ) {
-			fscanf ( dataFile, "%e", &etaMax        ) ;
+			fscanf ( dataFile, "%le", &etaMax        ) ;
 			continue ;
 		}  
 		if ( !strncmp(name,"phiMinTrack  ",   8) ) {
-			fscanf ( dataFile, "%e", &phiMinTrack   ) ;
+			fscanf ( dataFile, "%le", &phiMinTrack   ) ;
 			continue ;
 		}
 		if ( !strncmp(name,"phiMin       ",   6) ) {
-			fscanf ( dataFile, "%e", &phiMin        ) ;
+			fscanf ( dataFile, "%le", &phiMin        ) ;
 			continue ;
 		}  
 		if ( !strncmp(name,"phiMaxTrack  ",   8) ) {
-			fscanf ( dataFile, "%e", &phiMaxTrack   ) ;
+			fscanf ( dataFile, "%le", &phiMaxTrack   ) ;
 			continue ;
 		}
 		if ( !strncmp(name,"phiMax       ",   6) ) {
-			fscanf ( dataFile, "%e", &phiMax        ) ;
+			fscanf ( dataFile, "%le", &phiMax        ) ;
 			continue ;
 		}  
 		if ( !strncmp(name,"phiShift     ",   8) ) {
-			fscanf ( dataFile, "%e", &phiShift      ) ;
+			fscanf ( dataFile, "%le", &phiShift      ) ;
 			continue ;
 		}  
 		if ( !strncmp(name,"distanceMerge",   8) ) {
-			fscanf ( dataFile, "%e", &distanceMerge ) ;
+			fscanf ( dataFile, "%le", &distanceMerge ) ;
 			continue ;
 		}  
 		if ( !strncmp(name,"nPrimaryPasses",  8) ) {
@@ -176,79 +176,79 @@ void TrackFindingParameters::read ( char* inputFile )
 			continue ;
 		}  
 		if ( !strncmp(name,"bField",       6) ) {
-			fscanf ( dataFile, "%e", &bField ) ;
+			fscanf ( dataFile, "%le", &bField ) ;
 			continue ;
 		}  
 		if ( !strncmp(name,"maxChi2Primary",       12) ) {
-			fscanf ( dataFile, "%e", &maxChi2Primary ) ;
+			fscanf ( dataFile, "%le", &maxChi2Primary ) ;
 			continue ;
 		}  
 		if ( !strncmp(name,"hitChi2Cut",           8) ) {
-			fscanf ( dataFile, "%e", &hitChi2Cut ) ;
+			fscanf ( dataFile, "%le", &hitChi2Cut ) ;
 			continue ;
 		}  
 		if ( !strncmp(name,"goodHitChi2",           8) ) {
-			fscanf ( dataFile, "%e", &goodHitChi2 ) ;
+			fscanf ( dataFile, "%le", &goodHitChi2 ) ;
 			continue ;
 		}  
 		if ( !strncmp(name,"trackChi2Cut",           8) ) {
-			fscanf ( dataFile, "%e", &trackChi2Cut ) ;
+			fscanf ( dataFile, "%le", &trackChi2Cut ) ;
 			continue ;
 		} 
 		if ( !strncmp(name,"goodDistance",           8) ) {
-			fscanf ( dataFile, "%e", &goodDistance ) ;
+			fscanf ( dataFile, "%le", &goodDistance ) ;
 			continue ;
 		} 
 		if ( !strncmp(name,"ptMinHelixFit",           8) ) {
-			fscanf ( dataFile, "%e", &ptMinHelixFit ) ;
+			fscanf ( dataFile, "%le", &ptMinHelixFit ) ;
 			continue ;
 		} 
 		if ( !strncmp(name,"maxDistanceSegment",   15) ) {
-			fscanf ( dataFile, "%e", &maxDistanceSegment ) ;
+			fscanf ( dataFile, "%le", &maxDistanceSegment ) ;
 			continue ;
 		} 
 		if ( !strncmp(name,"xyErrorScale",   10) ) {
-			fscanf ( dataFile, "%e", &xyErrorScale ) ;
+			fscanf ( dataFile, "%le", &xyErrorScale ) ;
 			continue ;
 		} 
 		if ( !strncmp(name,"szErrorScale",   10) ) {
-			fscanf ( dataFile, "%e", &szErrorScale ) ;
+			fscanf ( dataFile, "%le", &szErrorScale ) ;
 			continue ;
 		} 
 		if ( !strncmp(name,"xVertex",   7) ) {
-			fscanf ( dataFile, "%e", &xVertex ) ;
+			fscanf ( dataFile, "%le", &xVertex ) ;
 			continue ;
 		} 
 		if ( !strncmp(name,"yVertex",   7) ) {
-			fscanf ( dataFile, "%e", &yVertex ) ;
+			fscanf ( dataFile, "%le", &yVertex ) ;
 			continue ;
 		} 
 		if ( !strncmp(name,"zVertex",   7) ) {
-			fscanf ( dataFile, "%e", &zVertex ) ;
+			fscanf ( dataFile, "%le", &zVertex ) ;
 			continue ;
 		} 
 		if ( !strncmp(name,"dxVertex",   8) ) {
-			fscanf ( dataFile, "%e", &dxVertex ) ;
+			fscanf ( dataFile, "%le", &dxVertex ) ;
 			continue ;
 		} 
 		if ( !strncmp(name,"dyVertex",   8) ) {
-			fscanf ( dataFile, "%e", &dyVertex ) ;
+			fscanf ( dataFile, "%le", &dyVertex ) ;
 			continue ;
 		} 
 		if ( !strncmp(name,"xyWeightVertex",   8) ) {
-			fscanf ( dataFile, "%e", &xyWeightVertex ) ;
+			fscanf ( dataFile, "%le", &xyWeightVertex ) ;
 			continue ;
 		} 
 		if ( !strncmp(name,"phiVertex",   8) ) {
-			fscanf ( dataFile, "%e", &phiVertex ) ;
+			fscanf ( dataFile, "%le", &phiVertex ) ;
 			continue ;
 		} 
 		if ( !strncmp(name,"rVertex",   7) ) {
-			fscanf ( dataFile, "%e", &rVertex ) ;
+			fscanf ( dataFile, "%le", &rVertex ) ;
 			continue ;
 		} 
 		if ( !strncmp(name,"maxTime",   7) ) {
-			fscanf ( dataFile, "%e", &maxTime ) ;
+			fscanf ( dataFile, "%le", &maxTime ) ;
 			continue ;
 		} 
 		printf ( "TrackFindingParameters::read: parameter %s not found \n", name ) ;


### PR DESCRIPTION
Still a few warnings:
 * One warning, which might point to a bug: https://github.com/iLCSoft/MarlinTrkProcessors/commit/0307de590d565ae6e8e1abb9480357924871489c
 * use of auto_ptr

 * this might also be a bug: https://github.com/iLCSoft/MarlinTrkProcessors/commit/2987b2d672830e857945e94b05b5d2e6c7518af8

 * effc++ is off

BEGINRELEASENOTES
- Fix many warnings for gcc
- ExtrToSIT::SelectBestCandidateLimited: remove variable shadowing pointer parameter
- ExtrToTracker: Fix bug when using performFinalRefit where the refitted track was not used after refit

ENDRELEASENOTES