### PR TITLE
TruthTrackFinder::sort_by_z: sort by absolute z

### DIFF
--- a/source/Refitting/src/TruthTrackFinder.cc
+++ b/source/Refitting/src/TruthTrackFinder.cc
@@ -141,9 +141,11 @@ bool sort_by_radius(EVENT::TrackerHit* hit1, EVENT::TrackerHit* hit2){
 }
 
 bool sort_by_z(EVENT::TrackerHit* hit1, EVENT::TrackerHit* hit2){
-	double z1 = hit1->getPosition()[2];
-	double z2 = hit2->getPosition()[2];
-  //return (z1 < z2);
+  // sorting by absolute value of Z so the hits are always sorted from close to
+  // the IP outward. This works as long as all hits are either in positive or
+  // negative side
+  const double z1 = fabs(hit1->getPosition()[2]);
+  const double z2 = fabs(hit2->getPosition()[2]);
   return CxxUtils::fpcompare::less(z1 , z2);
 }
 


### PR DESCRIPTION
For tracks going in -z direction the sorting by signed Z causes inversion of track direction leading to wrong charge and momentum direction. Thus sort hits by absolute Z.



BEGINRELEASENOTES
- TruthTrackFinder::sort_by_z: sort by absolute z. Fixes an issue with wrongly assigned charge and angle for tracks in the backward direction if the fit with hits sorted by radius failed.

ENDRELEASENOTES