### PR TITLE
Removing hits from the same layer

### DIFF
--- a/source/Refitting/include/TruthTrackFinder.h
+++ b/source/Refitting/include/TruthTrackFinder.h
@@ -15,7 +15,7 @@
 #include "MarlinTrk/IMarlinTrkSystem.h"
 #include "EVENT/TrackerHit.h"
 #include <UTIL/CellIDDecoder.h>
-
+#include "UTIL/LCTrackerConf.h"
 #include <AIDA/AIDA.h>
 
 using namespace lcio ;
@@ -48,18 +48,23 @@ class TruthTrackFinder : public Processor {
   // Call to get collections
   void getCollection(LCCollection*&, std::string, LCEvent*);
 	
-  // Get the subdetector ID from a hit
-  int getSubdetector(const TrackerHit*, UTIL::BitField64&);
-
-  // Get the layer ID from a hit
-  int getLayer(const TrackerHit*, UTIL::BitField64&);
-
-  // Remove hits in the same layer of the same subdetector
-  TrackerHitVec removeHitsSameLayer(const std::vector<TrackerHit*>, UTIL::BitField64&);
-
 	
  protected:
 	
+  // Encoder
+  UTIL::BitField64* m_encoder;
+
+  // Get the subdetector ID from a hit
+  int getSubdetector(const TrackerHit* hit){ m_encoder->setValue(hit->getCellID0()); return (*m_encoder)[lcio::LCTrackerCellID::subdet()]; } 
+
+  // Get the layer ID from a hit
+  int getLayer(const TrackerHit* hit){ m_encoder->setValue(hit->getCellID0()); return (*m_encoder)[lcio::LCTrackerCellID::layer()]; }
+
+  // Remove hits in the same layer of the same subdetector
+  void removeHitsSameLayer(const std::vector<TrackerHit*> &, std::vector<TrackerHit*> &);
+
+
+
   // Collection names for (in/out)put
   std::vector<std::string> m_inputTrackerHitCollections ;
   std::vector<std::string> m_inputTrackerHitRelationCollections ;

--- a/source/Refitting/include/TruthTrackFinder.h
+++ b/source/Refitting/include/TruthTrackFinder.h
@@ -49,13 +49,13 @@ class TruthTrackFinder : public Processor {
   void getCollection(LCCollection*&, std::string, LCEvent*);
 	
   // Get the subdetector ID from a hit
-  int getSubdetector(TrackerHit*, UTIL::BitField64&);
+  int getSubdetector(const TrackerHit*, UTIL::BitField64&);
 
   // Get the layer ID from a hit
-  int getLayer(TrackerHit*, UTIL::BitField64&);
+  int getLayer(const TrackerHit*, UTIL::BitField64&);
 
   // Remove hits in the same layer of the same subdetector
-  TrackerHitVec removeHitsSameLayer(std::vector<TrackerHit*>, UTIL::BitField64&);
+  TrackerHitVec removeHitsSameLayer(const std::vector<TrackerHit*>, UTIL::BitField64&);
 
 	
  protected:

--- a/source/Refitting/include/TruthTrackFinder.h
+++ b/source/Refitting/include/TruthTrackFinder.h
@@ -14,6 +14,7 @@
 #include <EVENT/LCCollection.h>
 #include "MarlinTrk/IMarlinTrkSystem.h"
 #include "EVENT/TrackerHit.h"
+#include <UTIL/CellIDDecoder.h>
 
 #include <AIDA/AIDA.h>
 
@@ -47,7 +48,14 @@ class TruthTrackFinder : public Processor {
   // Call to get collections
   void getCollection(LCCollection*&, std::string, LCEvent*);
 	
-  // Sort hits by radius
+  // Get the subdetector ID from a hit
+  int getSubdetector(TrackerHit*, UTIL::BitField64&);
+
+  // Get the layer ID from a hit
+  int getLayer(TrackerHit*, UTIL::BitField64&);
+
+  // Remove hits in the same layer of the same subdetector
+  TrackerHitVec removeHitsSameLayer(std::vector<TrackerHit*>, UTIL::BitField64&);
 
 	
  protected:

--- a/source/Refitting/src/TruthTrackFinder.cc
+++ b/source/Refitting/src/TruthTrackFinder.cc
@@ -489,21 +489,21 @@ void TruthTrackFinder::getCollection(LCCollection* &collection, std::string coll
   return;
 }
 
-int TruthTrackFinder::getSubdetector(TrackerHit* hit, UTIL::BitField64 &encoder){
+int TruthTrackFinder::getSubdetector(const TrackerHit* hit, UTIL::BitField64 &encoder){
   const int celId = hit->getCellID0() ;
   encoder.setValue(celId) ;
   int subdet = encoder[lcio::LCTrackerCellID::subdet()];
   return subdet;
 }
 
-int TruthTrackFinder::getLayer(TrackerHit* hit, UTIL::BitField64 &encoder){
+int TruthTrackFinder::getLayer(const TrackerHit* hit, UTIL::BitField64 &encoder){
   const int celId = hit->getCellID0() ;
   encoder.setValue(celId);
   int layer = encoder[lcio::LCTrackerCellID::layer()];
   return layer;
 }
   
-TrackerHitVec TruthTrackFinder::removeHitsSameLayer(std::vector<TrackerHit*> trackHits, UTIL::BitField64 &encoder){
+TrackerHitVec TruthTrackFinder::removeHitsSameLayer(const std::vector<TrackerHit*> trackHits, UTIL::BitField64 &encoder){
   EVENT::TrackerHitVec trackFilteredHits;
   trackFilteredHits.push_back(trackHits[0]);
 

--- a/source/Refitting/src/TruthTrackFinder.cc
+++ b/source/Refitting/src/TruthTrackFinder.cc
@@ -430,7 +430,7 @@ void TruthTrackFinder::processEvent( LCEvent* evt ) {
 
 
     ///Fill hits associated to the track by pattern recognition and hits in fit
-    UTIL::BitField64 encoder( lcio::LCTrackerCellID::encoding_string() ) ; 
+    //UTIL::BitField64 encoder( lcio::LCTrackerCellID::encoding_string() ) ; 
     encoder.reset() ;  // reset to 0
     MarlinTrk::addHitNumbersToTrack(track, trackHits, false, encoder);
     MarlinTrk::addHitNumbersToTrack(track, hits_in_fit, true, encoder);
@@ -507,7 +507,7 @@ TrackerHitVec TruthTrackFinder::removeHitsSameLayer(std::vector<TrackerHit*> tra
   EVENT::TrackerHitVec trackFilteredHits;
   trackFilteredHits.push_back(trackHits[0]);
 
-  for(int itHit=1;itHit<trackHits.size();itHit++){
+  for(unsigned int itHit=1;itHit<trackHits.size();itHit++){
     int subdet = getSubdetector(trackHits.at(itHit), encoder);
     int layer = getLayer(trackHits.at(itHit), encoder);
     if( subdet != getSubdetector(trackHits.at(itHit-1), encoder) )


### PR DESCRIPTION
BEGINRELEASENOTES
* TruthTrackFinder: hits in the same layer of the same subdetectors are now filtered. Those with higher radius are removed, then the fit is performed. In case the fit fails, those with higher z are removed and a new fit attempt is made.

ENDRELEASENOTES