### PR TITLE
Fix warnings

### DIFF
--- a/source/Refitting/include/FPCCDSiliconTracking_MarlinTrk.h
+++ b/source/Refitting/include/FPCCDSiliconTracking_MarlinTrk.h
@@ -760,7 +760,7 @@ protected:
        nsub.clear();
        mcp_d0 = mcp_z0 = mcp_omega = mcp_phi0 = mcp_tanL = 1e20;
      }
-     Triplet(const Triplet& obj){
+     Triplet(const Triplet& obj) : IMPL::TrackImpl(obj){
        *this = obj;
      }
   };
@@ -798,7 +798,7 @@ protected:
         purity = 1e20;
         simVecFromTrk.clear();
      }
-     BuildedTrack(const BuildedTrack& obj){
+     BuildedTrack(const BuildedTrack& obj) : IMPL::TrackImpl(obj){
        *this = obj;
      }
   };

--- a/source/Refitting/src/FPCCDFullLDCTracking_MarlinTrk.cc
+++ b/source/Refitting/src/FPCCDFullLDCTracking_MarlinTrk.cc
@@ -2081,7 +2081,7 @@ TrackExtended * FPCCDFullLDCTracking_MarlinTrk::CombineTracks(TrackExtended * tp
   
   streamlog_out(DEBUG2) << "FPCCDFullLDCTracking_MarlinTrk::CombineTracks: Start Fitting: AddHits: number of hits to fit " << trkHits.size() << std::endl;
   
-  std::auto_ptr<MarlinTrk::IMarlinTrack> marlin_trk_autop(_trksystem->createTrack());
+  std::unique_ptr<MarlinTrk::IMarlinTrack> marlin_trk_autop(_trksystem->createTrack());
   MarlinTrk::IMarlinTrack& marlin_trk = *marlin_trk_autop.get();
   
   IMPL::TrackStateImpl pre_fit ;

--- a/source/Refitting/src/FullLDCTracking_MarlinTrk.cc
+++ b/source/Refitting/src/FullLDCTracking_MarlinTrk.cc
@@ -1930,7 +1930,7 @@ TrackExtended * FullLDCTracking_MarlinTrk::CombineTracks(TrackExtended * tpcTrac
   
   streamlog_out(DEBUG2) << "FullLDCTracking_MarlinTrk::CombineTracks: Start Fitting: AddHits: number of hits to fit " << trkHits.size() << std::endl;
   
-  std::auto_ptr<MarlinTrk::IMarlinTrack> marlin_trk_autop(_trksystem->createTrack());
+  std::unique_ptr<MarlinTrk::IMarlinTrack> marlin_trk_autop(_trksystem->createTrack());
   MarlinTrk::IMarlinTrack& marlin_trk = *marlin_trk_autop.get();
   
   IMPL::TrackStateImpl pre_fit ;


### PR DESCRIPTION

BEGINRELEASENOTES
- Replace auto_ptr with unique_ptr
- explicitly call copy constructor of base class
ENDRELEASENOTES