### PR TITLE
TruthTrackFinder: drop use of gear nullptr

### DIFF
--- a/source/Refitting/src/TruthTrackFinder.cc
+++ b/source/Refitting/src/TruthTrackFinder.cc
@@ -160,8 +160,7 @@ void TruthTrackFinder::init() {
 	m_fitFails = 0;
   
   // Set up the track fit factory
-  const gear::GearMgr* fakeGear = 0;
-  trackFactory =  MarlinTrk::Factory::createMarlinTrkSystem( "DDKalTest" , fakeGear , "" ) ;
+  trackFactory =  MarlinTrk::Factory::createMarlinTrkSystem( "DDKalTest" , nullptr , "" ) ;
   trackFactory->setOption( MarlinTrk::IMarlinTrkSystem::CFG::useQMS,        true) ;
   trackFactory->setOption( MarlinTrk::IMarlinTrkSystem::CFG::usedEdx,       true) ;
   trackFactory->setOption( MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing,  false) ;


### PR DESCRIPTION
TruthTrackFinder: drop use of gear nullptr accidentally re-introduced in #13 