### PR TITLE
Tpc padplane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,46 @@
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+*.pyc
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Build and install directories
+bin/
+lib/
+/include
+python/
+build/
+
+# CMake config files
+*Config.cmake
+*ConfigVersion.cmake
+Version.h
+
+# emacs backup files
+*~
+

--- a/source/Digitisers/include/DDTPCDigiProcessor.h
+++ b/source/Digitisers/include/DDTPCDigiProcessor.h
@@ -176,8 +176,6 @@ protected:
   // gsl random number generator
   gsl_rng * _random {};
 
-  bool _dontEncodeSide {};
-
   float _pointResoRPhi0{}; // Coefficient for RPhi point res independant of drift length 
   float _pointResoPadPhi{}; // Coefficient for the point res dependance on relative phi angle to the pad verticle 
   float _diffRPhi{}; // Coefficient for the rphi point res dependance on diffusion 

--- a/source/Digitisers/include/DDTPCDigiProcessor.h
+++ b/source/Digitisers/include/DDTPCDigiProcessor.h
@@ -56,6 +56,7 @@ Steve Aplin 26 June 2009 (DESY)
 
 class Voxel_tpc;
 
+class TPCModularEndplate ;
 
 /** ====== DDTPCDigiProcessor ====== <br>
  *
@@ -97,6 +98,8 @@ class Voxel_tpc;
  * @authors F.Gaede, S. Aplin, DESY and A.Raspereza, MPI
  *
  * 06/2017 FG: replace Gear with DDRec
+ *         FG: remove hits that are inside the module gaps on the endplate (see parameters TPCEndPlateModulexxxx)
+ *             (set TPCEndPlateModuleGapPhi=0 to not remove any hits)
  * 
  * Changed 7/9/07 so that the const and diffusion resolution terms are taken as processor parameters rather than the gear file.
  * The parameters _pixZ and pixRP were also changed from gear parameters to processor parameters
@@ -111,6 +114,8 @@ public:
   
   
   DDTPCDigiProcessor() ;
+
+  ~DDTPCDigiProcessor() ;
   
   /** Called at the begin of the job before anything is read.
    * Use to initialize the processor, e.g. book histograms.
@@ -217,6 +222,15 @@ protected:
   const dd4hep::rec::FixedPadSizeTPCData*  _tpc{};
   double _bField{};
   
+
+  IntVec    _tpcEndPlateModuleNumbers{} ;
+  FloatVec _tpcEndPlateModulePhi0s{} ;
+  float    _tpcEndPlateModuleGapPhi{} ;
+  float    _tpcEndPlateModuleGapR{} ;
+
+  TPCModularEndplate* _tpcEP{} ;
+
+
 #ifdef DIGIPLOTS
   IAnalysisFactory * _AF{};
   ITreeFactory * _TRF{};

--- a/source/Digitisers/src/DDTPCDigiProcessor.cc
+++ b/source/Digitisers/src/DDTPCDigiProcessor.cc
@@ -163,10 +163,6 @@ DDTPCDigiProcessor::DDTPCDigiProcessor() : Processor("DDTPCDigiProcessor")
                              _maxMerge ,
                              (int)3) ;
 
-  registerProcessorParameter( "DontEncodeSide" ,
-                              "Do not encode the side in the cellID of the TrackerHit",
-                             _dontEncodeSide ,
-                             (bool) true ) ;
 }
 
 
@@ -1136,13 +1132,7 @@ void DDTPCDigiProcessor::writeVoxelToHit( Voxel_tpc* aVoxel){
   (*_cellid_encoder)[ lcio::LCTrackerCellID::subdet() ] = lcio::ILDDetID::TPC ;
   (*_cellid_encoder)[ lcio::LCTrackerCellID::layer()  ] = seed_hit->getRowIndex() ;
   (*_cellid_encoder)[ lcio::LCTrackerCellID::module() ] = 0 ;
-  
-  
-  //fg: optionally encode the side (should become the default eventually)
-  if( ! _dontEncodeSide )
-    (*_cellid_encoder)[ lcio::LCTrackerCellID::side()   ] = ( pos[2] < 0 ?  -1 : 1 ) ;
-  else
-    (*_cellid_encoder)[ lcio::LCTrackerCellID::side()   ] = lcio::ILDDetID::barrel ;
+  (*_cellid_encoder)[ lcio::LCTrackerCellID::side()   ] = ( pos[2] < 0 ?  -1 : 1 ) ;
 
   _cellid_encoder->setCellID( trkHit ) ;
   
@@ -1303,12 +1293,7 @@ void DDTPCDigiProcessor::writeMergedVoxelsToHit( vector <Voxel_tpc*>* hitsToMerg
   (*_cellid_encoder)[ lcio::LCTrackerCellID::subdet() ] = lcio::ILDDetID::TPC ;
   (*_cellid_encoder)[ lcio::LCTrackerCellID::layer()  ] = row ;
   (*_cellid_encoder)[ lcio::LCTrackerCellID::module() ] = 0 ;
-
-  //fg: optionally encode the side (should become the default eventually)
-  if( ! _dontEncodeSide )
-    (*_cellid_encoder)[ lcio::LCTrackerCellID::side()   ] = ( pos[2] < 0 ?  -1 : 1 ) ;
-  else
-    (*_cellid_encoder)[ lcio::LCTrackerCellID::side()   ] = lcio::ILDDetID::barrel ;
+  (*_cellid_encoder)[ lcio::LCTrackerCellID::side()   ] = ( pos[2] < 0 ?  -1 : 1 ) ;
 
   _cellid_encoder->setCellID( trkHit ) ;
   

--- a/source/Digitisers/src/TPCModularEndplate.cc
+++ b/source/Digitisers/src/TPCModularEndplate.cc
@@ -1,0 +1,71 @@
+
+#include "TPCModularEndplate.h"
+
+#include <DD4hep/DD4hepUnits.h>
+
+#include <math.h>
+
+
+TPCModularEndplate::TPCModularEndplate( const dd4hep::rec::FixedPadSizeTPCData* tpc ) : _tpc( tpc) { }
+
+
+void TPCModularEndplate::addModuleRing( unsigned nModules, double phi0 ){
+
+  if( isInitialized ){
+    throw std::runtime_error("TPCModularEndplate: addModuleRing() called after initialize() ") ; 
+  }
+  
+  _moduleRings.push_back( { nModules, phi0, 0 , 0 , 0 } )  ;
+}
+
+
+void TPCModularEndplate::initialize(){
+
+  unsigned nRing = _moduleRings.size() ;
+
+  double deltaR = ( _tpc->rMaxReadout  - _tpc->rMinReadout ) /  nRing ;
+
+  double rMin = _tpc->rMinReadout ;
+
+  double rMax = rMin + deltaR ;
+
+  for( auto modRing : _moduleRings){
+
+    modRing.rMin = rMin ;
+    modRing.rMax = rMax ;
+
+    modRing.deltaPhi =  2. * M_PI / modRing.nModules ;  
+    
+    rMin += deltaR ;
+    rMax += deltaR ;
+  }
+
+  isInitialized = true ; 
+}
+
+
+
+double TPCModularEndplate::computeDistanceRPhi(const dd4hep::rec::Vector3D& hit){
+
+  if( !isInitialized ){
+    throw std::runtime_error("TPCModularEndplate: computeDistanceRPhi() called before initialize() ") ; 
+  }
+  
+  unsigned indexR = _moduleRings.size() * ( hit.r()  - _tpc->rMinReadout )  / ( _tpc->rMaxReadout  - _tpc->rMinReadout )  ;
+
+  auto modRing = _moduleRings.at( indexR )  ;
+
+  double phi = hit.phi() - modRing.phi0   ;
+
+  double deltaPhi  = std::fabs( std::fmod(  ( phi - modRing.phi0 ) , modRing.deltaPhi ) );
+
+  if( deltaPhi > modRing.deltaPhi/2. ) {
+
+    deltaPhi = modRing.deltaPhi - deltaPhi ;
+  }  
+
+  return hit.r() * deltaPhi ;
+
+}
+  
+  

--- a/source/Digitisers/src/TPCModularEndplate.cc
+++ b/source/Digitisers/src/TPCModularEndplate.cc
@@ -2,6 +2,7 @@
 #include "TPCModularEndplate.h"
 
 #include <DD4hep/DD4hepUnits.h>
+#include "marlin/VerbosityLevels.h"
 
 #include <math.h>
 
@@ -23,13 +24,13 @@ void TPCModularEndplate::initialize(){
 
   unsigned nRing = _moduleRings.size() ;
 
-  double deltaR = ( _tpc->rMaxReadout  - _tpc->rMinReadout ) /  nRing ;
+  double deltaR = ( _tpc->rMaxReadout/dd4hep::mm  - _tpc->rMinReadout/dd4hep::mm ) /  nRing ;
 
-  double rMin = _tpc->rMinReadout ;
+  double rMin = _tpc->rMinReadout/dd4hep::mm ;
 
   double rMax = rMin + deltaR ;
 
-  for( auto modRing : _moduleRings){
+  for( auto& modRing : _moduleRings){
 
     modRing.rMin = rMin ;
     modRing.rMax = rMax ;
@@ -51,7 +52,15 @@ double TPCModularEndplate::computeDistanceRPhi(const dd4hep::rec::Vector3D& hit)
     throw std::runtime_error("TPCModularEndplate: computeDistanceRPhi() called before initialize() ") ; 
   }
   
-  unsigned indexR = _moduleRings.size() * ( hit.r()  - _tpc->rMinReadout )  / ( _tpc->rMaxReadout  - _tpc->rMinReadout )  ;
+  unsigned indexR = std::floor( _moduleRings.size() * ( hit.rho()  - _tpc->rMinReadout/dd4hep::mm )  / ( _tpc->rMaxReadout/dd4hep::mm  - _tpc->rMinReadout/dd4hep::mm )  ) ;
+
+  if( indexR > _moduleRings.size() -1 ){
+
+    streamlog_out( WARNING ) << " wrong index  : " << indexR << " for point " << hit << std::endl ;
+
+    return 1e6 ;
+  }
+
 
   auto modRing = _moduleRings.at( indexR )  ;
 
@@ -64,7 +73,7 @@ double TPCModularEndplate::computeDistanceRPhi(const dd4hep::rec::Vector3D& hit)
     deltaPhi = modRing.deltaPhi - deltaPhi ;
   }  
 
-  return hit.r() * deltaPhi ;
+  return hit.rho() * deltaPhi ;
 
 }
   

--- a/source/Digitisers/src/TPCModularEndplate.h
+++ b/source/Digitisers/src/TPCModularEndplate.h
@@ -1,0 +1,60 @@
+#ifndef TPCModularEndplate_h
+#define TPCModularEndplate_h
+
+#include <DDRec/DetectorData.h>
+#include <DDRec/Vector3D.h>
+
+#include <vector>
+
+/** Helper class for defining a modular TPC endplate with regular modules.
+ *  Computes the distance from a module boundary for hits.
+ * 
+ * @author F.Gaede, DESY
+ * @date June, 2017 
+ */
+
+class TPCModularEndplate {
+
+public:
+
+  /// internal helper struct
+  struct ModuleRing{
+    unsigned nModules ;
+    double phi0 ;
+    double rMin ;
+    double rMax ;
+    double deltaPhi ;
+  } ;
+
+
+  /// no default c'tor
+  TPCModularEndplate() = delete ;
+  
+
+  /// intitialize for the gice TPC data
+  TPCModularEndplate( const dd4hep::rec::FixedPadSizeTPCData* tpc ) ;
+   
+  /// add a module ring with the given number of modules and phi0 - modules are added inside out.
+  void addModuleRing( unsigned nModules, double phi0 ) ;
+
+  
+  /// inititalize with the modules added so far - after this no more modules can be added.
+  void initialize() ;
+
+
+  /// compute the distance in the rphi-plane from a module boundary in mm. 
+  double computeDistanceRPhi( const dd4hep::rec::Vector3D& hit) ;
+  
+  
+protected:
+
+  std::vector<ModuleRing> _moduleRings{} ; 
+
+  const dd4hep::rec::FixedPadSizeTPCData* _tpc{} ;
+
+  bool isInitialized{ false } ;
+
+
+} ;
+
+#endif


### PR DESCRIPTION

BEGINRELEASENOTES
- remove hits that are in module gaps on the TPC endplate in DDTPCDigiProcessor
      - use the following parameters to define the endplate:
      - TPCEndPlateModuleNumbers
      - TPCEndPlateModulePhi0s
      - TPCEndPlateModuleGapPhi



ENDRELEASENOTES