### PR TITLE
Cleanup

### DIFF
--- a/source/Refitting/src/FPCCDFullLDCTracking_MarlinTrk.cc
+++ b/source/Refitting/src/FPCCDFullLDCTracking_MarlinTrk.cc
@@ -96,10 +96,6 @@ namespace FPCCDUtil{
 FPCCDFullLDCTracking_MarlinTrk::FPCCDFullLDCTracking_MarlinTrk() : Processor("FPCCDFullLDCTracking_MarlinTrk") {  
   _description = "Performs full tracking in ILD detector" ;  
   
-
-  _moriUtil = new moriUTIL();
-  _purityUtil = new GetPurityUtil();
-  
   // Input tracker hit collections
   
   registerInputCollection(LCIO::TRACKERHITPLANE,
@@ -607,6 +603,9 @@ void FPCCDFullLDCTracking_MarlinTrk::init() {
   TWOPI = 2*PI;
 
   _encoder = new UTIL::BitField64(lcio::LCTrackerCellID::encoding_string());
+
+  _moriUtil = new moriUTIL();
+  _purityUtil = new GetPurityUtil();
 
   
   // set up the geometery needed by KalTest
@@ -5354,7 +5353,11 @@ bool FPCCDFullLDCTracking_MarlinTrk::VetoMerge(TrackExtended* firstTrackExt, Tra
 void FPCCDFullLDCTracking_MarlinTrk::check(LCEvent* ) { }
 
 void FPCCDFullLDCTracking_MarlinTrk::end() { 
-  
+
+
+  delete _moriUtil;
+  delete _purityUtil;
+
   delete _encoder ;
   
 }

--- a/source/Refitting/src/SiliconTracking_MarlinTrk.cc
+++ b/source/Refitting/src/SiliconTracking_MarlinTrk.cc
@@ -162,9 +162,6 @@ SiliconTracking_MarlinTrk::SiliconTracking_MarlinTrk() : Processor("SiliconTrack
   
   _description = "Pattern recognition in silicon trackers";
   
-  _fastfitter = new MarlinTrk::HelixFit();
-  
-  
   _petalBasedFTDWithOverlaps = false;
   
   // zero triplet counters
@@ -569,6 +566,8 @@ void SiliconTracking_MarlinTrk::init() {
   _nEvt = 0 ;
 
   _encoder = new UTIL::BitField64(lcio::LCTrackerCellID::encoding_string());
+
+  _fastfitter = new MarlinTrk::HelixFit();
 
   printParameters() ;
   


### PR DESCRIPTION
getting rid of the last "definite" leaks in reconstruction

BEGINRELEASENOTES
- SiliconTracking_MarlinTrk: initialise fastfitter in init function, fixes small memory leak if processor is not active

- FPCCDFullLDCTracking_MarlinTrk: initalise helper objects in init and add cleanup in end. Fixes small memory leaks 



ENDRELEASENOTES