### PR TITLE
configure MarlinTrkSystem per event in all processors

### DIFF
--- a/source/Refitting/src/DDCellsAutomatonMV.cc
+++ b/source/Refitting/src/DDCellsAutomatonMV.cc
@@ -321,6 +321,11 @@ void DDCellsAutomatonMV::processRunHeader( LCRunHeader* ) {
 
 void DDCellsAutomatonMV::processEvent( LCEvent * evt ) {
 
+  // set the correct configuration for the tracking system for this event 
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useQMS>       mson( _trkSystem,  _MSOn ) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::usedEdx>      elosson( _trkSystem,_ElossOn) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing> smoothon( _trkSystem,_SmoothOn) ;
+
   TrackerHitVec HitsTemp; //Hits to be deleted at the end
   std::vector< IHit* > hitsTBD; //Hits to be deleted at the end
   //std::vector< IHit* > MiniVectorsTemp;

--- a/source/Refitting/src/ExtrToSIT.cc
+++ b/source/Refitting/src/ExtrToSIT.cc
@@ -242,6 +242,11 @@ void ExtrToSIT::processRunHeader( LCRunHeader* ) {
 void ExtrToSIT::processEvent( LCEvent * evt ) { 
 
 
+  // set the correct configuration for the tracking system for this event 
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useQMS>       mson( _trksystem,  _MSOn ) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::usedEdx>      elosson( _trksystem,_ElossOn) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing> smoothon( _trksystem,_SmoothOn) ;
+
   //-- note: this will not be printed if compiled w/o MARLINDEBUG=1 !
   
   streamlog_out(DEBUG1) << "   processing event: " << _n_evt 

--- a/source/Refitting/src/ExtrToTracker.cc
+++ b/source/Refitting/src/ExtrToTracker.cc
@@ -208,6 +208,11 @@ void ExtrToTracker::processRunHeader( LCRunHeader* ) {
 void ExtrToTracker::processEvent( LCEvent * evt ) { 
 
 
+  // set the correct configuration for the tracking system for this event 
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useQMS>       mson( _trksystem,  _MSOn ) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::usedEdx>      elosson( _trksystem,_ElossOn) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing> smoothon( _trksystem,_SmoothOn) ;
+
   //printParameters();
 
 

--- a/source/Refitting/src/FPCCDFullLDCTracking_MarlinTrk.cc
+++ b/source/Refitting/src/FPCCDFullLDCTracking_MarlinTrk.cc
@@ -649,6 +649,11 @@ void FPCCDFullLDCTracking_MarlinTrk::processRunHeader( LCRunHeader* run) {
 
 void FPCCDFullLDCTracking_MarlinTrk::processEvent( LCEvent * evt ) { 
   
+  // set the correct configuration for the tracking system for this event 
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useQMS>       mson( _trksystem,  _MSOn ) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::usedEdx>      elosson( _trksystem,_ElossOn) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing> smoothon( _trksystem,_SmoothOn) ;
+
   _evt = evt;
   
 

--- a/source/Refitting/src/FPCCDSiliconTracking_MarlinTrk.cc
+++ b/source/Refitting/src/FPCCDSiliconTracking_MarlinTrk.cc
@@ -658,6 +658,11 @@ void FPCCDSiliconTracking_MarlinTrk::processEvent( LCEvent * evt ) {
     _timer.inAnEvt.Start();
   }
 
+  // set the correct configuration for the tracking system for this event 
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useQMS>       mson( _trksystem,  _MSOn ) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::usedEdx>      elosson( _trksystem,_ElossOn) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing> smoothon( _trksystem,_SmoothOn) ;
+
   //check
   std::cout << "=========== evt num : " << _nEvt << "  =================" << std::endl;
 

--- a/source/Refitting/src/FullLDCTracking_MarlinTrk.cc
+++ b/source/Refitting/src/FullLDCTracking_MarlinTrk.cc
@@ -553,6 +553,11 @@ void FullLDCTracking_MarlinTrk::processRunHeader( LCRunHeader* run) {
 
 void FullLDCTracking_MarlinTrk::processEvent( LCEvent * evt ) { 
   
+  // set the correct configuration for the tracking system for this event 
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useQMS>       mson( _trksystem,  _MSOn ) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::usedEdx>      elosson( _trksystem,_ElossOn) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing> smoothon( _trksystem,_SmoothOn) ;
+
   _evt = evt;
   
   

--- a/source/Refitting/src/RefitFinal.cc
+++ b/source/Refitting/src/RefitFinal.cc
@@ -111,6 +111,11 @@ void RefitFinal::processRunHeader(LCRunHeader *) { ++_n_run; }
 
 void RefitFinal::processEvent(LCEvent *evt) {
 
+  // set the correct configuration for the tracking system for this event 
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useQMS>       mson( _trksystem,  _MSOn ) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::usedEdx>      elosson( _trksystem,_ElossOn) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing> smoothon( _trksystem,_SmoothOn) ;
+
   ++_n_evt;
 
   // get input collection and relations

--- a/source/Refitting/src/RefitProcessor.cc
+++ b/source/Refitting/src/RefitProcessor.cc
@@ -182,6 +182,11 @@ void RefitProcessor::processRunHeader( LCRunHeader* ) {
 void RefitProcessor::processEvent( LCEvent * evt ) { 
   
   
+  // set the correct configuration for the tracking system for this event 
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useQMS>       mson( _trksystem,  _MSOn ) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::usedEdx>      elosson( _trksystem,_ElossOn) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing> smoothon( _trksystem,_SmoothOn) ;
+
   //-- note: this will not be printed if compiled w/o MARLINDEBUG=1 !
   
   streamlog_out(DEBUG4) << "   processing event: " << _n_evt 

--- a/source/Refitting/src/SiliconTracking_MarlinTrk.cc
+++ b/source/Refitting/src/SiliconTracking_MarlinTrk.cc
@@ -691,6 +691,11 @@ void SiliconTracking_MarlinTrk::processRunHeader( LCRunHeader* ) {
 
 void SiliconTracking_MarlinTrk::processEvent( LCEvent * evt ) { 
   
+  // set the correct configuration for the tracking system for this event 
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useQMS>       mson( _trksystem,  _MSOn ) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::usedEdx>      elosson( _trksystem,_ElossOn) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing> smoothon( _trksystem,_SmoothOn) ;
+
   _current_event = evt;
   
   _output_track_col_quality = _output_track_col_quality_GOOD;

--- a/source/Refitting/src/TrackSubsetProcessor.cc
+++ b/source/Refitting/src/TrackSubsetProcessor.cc
@@ -183,6 +183,10 @@ void TrackSubsetProcessor::processRunHeader( LCRunHeader* ) {
 void TrackSubsetProcessor::processEvent( LCEvent * evt ) { 
 
    
+  // set the correct configuration for the tracking system for this event 
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useQMS>       mson( _trkSystem,  _MSOn ) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::usedEdx>      elosson( _trkSystem,_ElossOn) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing> smoothon( _trkSystem,_SmoothOn) ;
    
   std::vector< Track* > tracks;
   
@@ -206,7 +210,7 @@ void TrackSubsetProcessor::processEvent( LCEvent * evt ) {
     }
     catch(DataNotAvailableException &e) {
       
-      streamlog_out( ERROR ) << "Collection " << _trackInputColNames[i] <<  " is not available!\n";     
+      streamlog_out( DEBUG7 ) << "Collection " << _trackInputColNames[i] <<  " is not available!\n";
       continue;
       
     }

--- a/source/Refitting/src/TruthTrackFinder.cc
+++ b/source/Refitting/src/TruthTrackFinder.cc
@@ -190,6 +190,11 @@ void TruthTrackFinder::processRunHeader( LCRunHeader* ) {
 
 void TruthTrackFinder::processEvent( LCEvent* evt ) {
 
+  // set the correct configuration for the tracking system for this event 
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useQMS>       mson(     trackFactory, true  ) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::usedEdx>      elosson(  trackFactory, true  ) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing> smoothon( trackFactory, false ) ;
+
   // Get the collection of MC particles
   LCCollection* particleCollection = 0 ;
   getCollection(particleCollection, m_inputParticleCollection, evt); if(particleCollection == 0) return;

--- a/source/Refitting/src/TruthTracker.cc
+++ b/source/Refitting/src/TruthTracker.cc
@@ -320,6 +320,11 @@ void TruthTracker::processRunHeader( LCRunHeader* ) {
 
 void TruthTracker::processEvent( LCEvent * evt ) { 
   
+  // set the correct configuration for the tracking system for this event 
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useQMS>       mson( _trksystem,  _MSOn ) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::usedEdx>      elosson( _trksystem,_ElossOn) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing> smoothon( _trksystem,_SmoothOn) ;
+
   _current_event = evt;
   
   streamlog_out(DEBUG3) << "   processing event: " << _n_evt << std::endl ;


### PR DESCRIPTION
BEGINRELEASENOTES
- set correct MarlinTrkSystem configuration for every event with `MarlinTrk::TrkSysConfig`
   in all tracking processors

ENDRELEASENOTES

needs: iLCSoft/MarlinTrk#7