### PR TITLE
ClonesAndSplitTracksFinder: added option to run clones skimming only

### DIFF
--- a/source/Refitting/include/ClonesAndSplitTracksFinder.h
+++ b/source/Refitting/include/ClonesAndSplitTracksFinder.h
@@ -74,6 +74,8 @@ protected:
 
   double _maxDeltaTheta = 0.0, _maxDeltaPhi = 0.0, _maxDeltaPt = 0.0;
 
+  bool _clonesOnly = true;
+
   // Track fit parameters
   double _initialTrackError_d0;
   double _initialTrackError_phi0;

--- a/source/Refitting/include/ClonesAndSplitTracksFinder.h
+++ b/source/Refitting/include/ClonesAndSplitTracksFinder.h
@@ -56,6 +56,12 @@ protected:
   // Removes doubles (from clone treatments and track merging) and filters multiple connections (clones and mergeable tracks treated differently)
   void filterClonesAndMergedTracks(std::multimap<int,std::pair<int,Track*>>&, LCCollection*&, TrackVec&, bool);
 
+  // Contains the whole merging procedure (calls filterClonesAndMergedTracks(bool false) and mergeAndFit)
+  void mergeSplitTracks(std::unique_ptr<LCCollectionVec>&, LCCollection*&, EVENT::TrackVec&);
+
+  // Contains the whole clone skimming procedure (calls bestInClones and filterClonesAndMergedTracks(bool true))
+  void removeClones(EVENT::TrackVec&, LCCollection*&);
+
   lcio::LCCollection *GetCollection(lcio::LCEvent *evt, std::string colName);
 
   std::string _input_track_col_name;
@@ -74,7 +80,7 @@ protected:
 
   double _maxDeltaTheta = 0.0, _maxDeltaPhi = 0.0, _maxDeltaPt = 0.0;
 
-  bool _clonesOnly = true;
+  bool _mergeSplitTracks = false;
 
   // Track fit parameters
   double _initialTrackError_d0;


### PR DESCRIPTION
BEGINRELEASENOTES
- ClonesAndSplitTracksFinder: added mergeSplitTracks parameter, that allows one to decide whether to run only the clones skimming or also the merging of split tracks
  - mergeSplitTracks = false by default
  - mergeSplitTracks = true would enable the treatment of split tracks, which is still work in progress

ENDRELEASENOTES