### PR TITLE
Added two options, to use simple updated triplets searching core bin,…

### DIFF
--- a/source/Refitting/include/SiliconTracking_MarlinTrk.h
+++ b/source/Refitting/include/SiliconTracking_MarlinTrk.h
@@ -232,7 +232,13 @@ protected:
   std::string _MarlinTrkDiagnosticsName;
   
   bool _MSOn, _ElossOn, _SmoothOn ;
-  
+
+  /** switches: False for backward compatible (default).
+                True to apply new methods.
+   */
+  bool _useSimpleUpdatedCoreBin;
+  bool _useSimpleAttachHitToTrack;
+
   float _initialTrackError_d0;
   float _initialTrackError_phi0;
   float _initialTrackError_omega;


### PR DESCRIPTION
… and to use simple AttachHitToTrack for merging split track segments.



BEGINRELEASENOTES
- Improved SiliconTracking_MarlinTrk - added two options:
     - to use simple updated triplets searching core bin,
     - to use simple "AttachHitToTrack" for merging split track segments.

ENDRELEASENOTES