### PR TITLE
fix B-field correction for the r-phi resolution

### DIFF
--- a/source/Digitisers/src/DDTPCDigiProcessor.cc
+++ b/source/Digitisers/src/DDTPCDigiProcessor.cc
@@ -763,8 +763,10 @@ void DDTPCDigiProcessor::processEvent( LCEvent * evt )
       
       padheight = _tpc->padHeight/dd4hep::mm ; 
       
-      double bReso = ( (_diffRPhi * _diffRPhi) / _nEff ) * sin(padTheta) * ( 6.0 / (padheight) )  * ( 4.0 / _bField  ) ;
-      
+      //double bReso = ( (_diffRPhi * _diffRPhi) / _nEff ) * sin(padTheta) * ( 6.0 / (padheight) )  * ( 4.0 / _bField  ) ;
+      // formula with new quadratic B-field correction term
+      double bReso = ( (_diffRPhi * _diffRPhi) / _nEff ) * sin(padTheta) * ( 6.0 / (padheight) ) * ( (4.0 * 4.0) / (_bField * _bField) ) ;
+
       double tpcRPhiRes = sqrt( aReso + bReso * (driftLength / 10.0) ); // driftLength in cm
       
       double tpcZRes  = sqrt(( _pointResoZ0 * _pointResoZ0 ) 


### PR DESCRIPTION
    



BEGINRELEASENOTES
- fixed DDTPCDigiProcessor
    - fix B-field correction for the r-phi resolution
    - now use (4./B)^2 rather than 4./B
 
ENDRELEASENOTES