### PR TITLE
RefitFinal: min number of hits on track after fit as a processor para…

### DIFF
--- a/source/Refitting/include/RefitFinal.h
+++ b/source/Refitting/include/RefitFinal.h
@@ -80,6 +80,7 @@ protected:
   float _bField = 0.0;
 
   bool _extrapolateForward = true;
+  int _minClustersOnTrackAfterFit = 0;
 
   std::shared_ptr<UTIL::BitField64> _encoder{};
 };

--- a/source/Refitting/src/RefitFinal.cc
+++ b/source/Refitting/src/RefitFinal.cc
@@ -77,6 +77,10 @@ RefitFinal::RefitFinal() : Processor("RefitFinal") {
                              "if true extrapolation in the forward direction "
                              "(in-out), otherwise backward (out-in)",
                              _extrapolateForward, _extrapolateForward);
+
+  registerProcessorParameter("MinClustersOnTrackAfterFit", "Final minimum number of track clusters",
+                             _minClustersOnTrackAfterFit, int(4));
+
 }
 
 void RefitFinal::init() {
@@ -205,8 +209,8 @@ void RefitFinal::processEvent(LCEvent *evt) {
 
     marlin_trk->getHitsInFit(hits_in_fit);
 
-    if (hits_in_fit.size() < 3) {
-      streamlog_out(DEBUG3) << "Less than 3 hits in fit: Track "
+    if (int(hits_in_fit.size()) < _minClustersOnTrackAfterFit) {
+      streamlog_out(DEBUG3) << "Less than " << _minClustersOnTrackAfterFit << " hits in fit: Track "
                                "Discarded. Number of hits =  "
                             << trkHits.size() << std::endl;
       continue;


### PR DESCRIPTION
…meter



BEGINRELEASENOTES
- RefitFinal: added processor parameter `MinClustersOnTrackAfterFit`
  - defines the minimum number of hits on track after the fit for the track to be accepted 
  - previously hard-coded = 3, but tracks with 3 hits are ~100% fakes
  - now implemented as in ConformalTracking ilcsoft/ConformalTracking#52

ENDRELEASENOTES