### PR TITLE
Merging duplicate tracks

### DIFF
--- a/source/Refitting/include/ClonesAndSplitTracksFinder.h
+++ b/source/Refitting/include/ClonesAndSplitTracksFinder.h
@@ -11,39 +11,37 @@
 #include <cfloat>
 
 namespace MarlinTrk {
-class IMarlinTrkSystem;
-class IMarlinTrack;
+  class IMarlinTrkSystem;
+  class IMarlinTrack;
 }
 
 class ClonesAndSplitTracksFinder : public marlin::Processor {
-
 public:
-  virtual marlin::Processor *newProcessor() { return new ClonesAndSplitTracksFinder; }
+  virtual marlin::Processor* newProcessor() { return new ClonesAndSplitTracksFinder; }
 
   ClonesAndSplitTracksFinder();
-  ClonesAndSplitTracksFinder(const ClonesAndSplitTracksFinder &) = delete;
-  ClonesAndSplitTracksFinder &operator=(const ClonesAndSplitTracksFinder &) = delete;
+  ClonesAndSplitTracksFinder(const ClonesAndSplitTracksFinder&) = delete;
+  ClonesAndSplitTracksFinder& operator=(const ClonesAndSplitTracksFinder&) = delete;
 
   // Initialisation - run at the beginning to start histograms, etc.
   virtual void init();
 
   // Called at the beginning of every run
-  virtual void processRunHeader(lcio::LCRunHeader *run);
+  virtual void processRunHeader(lcio::LCRunHeader* run);
 
   // Run over each event - the main algorithm
-  virtual void processEvent(lcio::LCEvent *evt);
+  virtual void processEvent(lcio::LCEvent* evt);
 
   // Run at the end of each event
-  virtual void check(lcio::LCEvent *evt);
+  virtual void check(lcio::LCEvent* evt);
 
   // Called at the very end for cleanup, histogram saving, etc.
   virtual void end();
 
 protected:
-
   // Checks for overlapping hits
   int overlappingHits(const Track*, const Track*);
-  
+
   // Picks up the best track between two clones (based on chi2 and length requirements)
   void bestInClones(Track*, Track*, int, Track*&);
 
@@ -54,43 +52,44 @@ protected:
   void mergeAndFit(Track*, Track*, Track*&);
 
   // Removes doubles (from clone treatments and track merging) and filters multiple connections (clones and mergeable tracks treated differently)
-  void filterClonesAndMergedTracks(std::multimap<int,std::pair<int,Track*>>&, LCCollection*&, TrackVec&, bool);
+  void filterClonesAndMergedTracks(std::multimap<int, std::pair<int, Track*>>&, LCCollection*&, TrackVec&, bool);
 
   // Contains the whole merging procedure (calls filterClonesAndMergedTracks(bool false) and mergeAndFit)
   void mergeSplitTracks(std::unique_ptr<LCCollectionVec>&, LCCollection*&, EVENT::TrackVec&);
 
   // Calculate significance in pt for two candidate clones
-  double calculateSignificancePt(const Track *, const Track *);
+  double calculateSignificancePt(const Track*, const Track*);
 
   // Calculate significance in phi for two candidate clones
-  double calculateSignificancePhi(const Track *, const Track *);
+  double calculateSignificancePhi(const Track*, const Track*);
 
   // Calculate significance in tanLambda for two candidate clones
-  double calculateSignificanceTanLambda(const Track *, const Track *);
+  double calculateSignificanceTanLambda(const Track*, const Track*);
 
   // Calculate significance for two candidate clones
-  double calculateSignificance(const double firstPar, const double secondPar, const double firstPar_sigma, const double secondPar_sigma );
+  double calculateSignificance(const double firstPar, const double secondPar, const double firstPar_sigma,
+                               const double secondPar_sigma);
 
   // Contains the whole clone skimming procedure (calls bestInClones and filterClonesAndMergedTracks(bool true))
   void removeClones(EVENT::TrackVec&, LCCollection*&);
 
-  lcio::LCCollection *GetCollection(lcio::LCEvent *evt, std::string colName);
+  lcio::LCCollection* GetCollection(lcio::LCEvent* evt, std::string colName);
 
   std::string _input_track_col_name;
   std::string _output_track_col_name;
 
-  MarlinTrk::IMarlinTrkSystem *_trksystem = nullptr;
+  MarlinTrk::IMarlinTrkSystem* _trksystem = nullptr;
 
   int _n_run = -1;
   int _n_evt = -1;
 
-  bool _MSOn = true;
-  bool _ElossOn = true;
-  bool _SmoothOn = false;
-  double _magneticField = 0.0;
-  bool _extrapolateForward = true;
+  bool   _MSOn               = true;
+  bool   _ElossOn            = true;
+  bool   _SmoothOn           = false;
+  double _magneticField      = 0.0;
+  bool   _extrapolateForward = true;
 
-  double _minPt = 1.0;
+  double _minPt                = 1.0;
   double _maxSignificanceTheta = 0.0, _maxSignificancePhi = 0.0, _maxSignificancePt = 0.0;
 
   bool _mergeSplitTracks = false;
@@ -104,7 +103,6 @@ protected:
   double _maxChi2perHit;
 
   std::shared_ptr<UTIL::BitField64> _encoder{};
-
 };
 
 #endif

--- a/source/Refitting/include/ClonesAndSplitTracksFinder.h
+++ b/source/Refitting/include/ClonesAndSplitTracksFinder.h
@@ -66,6 +66,12 @@ protected:
   // Calculate significance in phi for two candidate clones
   double calculateSignificancePhi(Track *, Track *);
 
+  // Calculate significance in tanLambda for two candidate clones
+  double calculateSignificanceTanLambda(Track *, Track *);
+
+  // Calculate significance for two candidate clones
+  double calculateSignificance(const double firstPar, const double secondPar, const double firstPar_sigma, const double secondPar_sigma );
+
   // Contains the whole clone skimming procedure (calls bestInClones and filterClonesAndMergedTracks(bool true))
   void removeClones(EVENT::TrackVec&, LCCollection*&);
 
@@ -89,7 +95,7 @@ protected:
   bool _extrapolateForward = true;
 
   double _minPt = 1.0;
-  double _maxDeltaTheta = 0.0, _maxDeltaPhi = 0.0, _maxDeltaPt = 0.0;
+  double _maxSignificanceTheta = 0.0, _maxSignificancePhi = 0.0, _maxSignificancePt = 0.0;
 
   bool _mergeSplitTracks = false;
 

--- a/source/Refitting/include/ClonesAndSplitTracksFinder.h
+++ b/source/Refitting/include/ClonesAndSplitTracksFinder.h
@@ -62,6 +62,9 @@ protected:
   // Contains the whole clone skimming procedure (calls bestInClones and filterClonesAndMergedTracks(bool true))
   void removeClones(EVENT::TrackVec&, LCCollection*&);
 
+  void printHits(const Track*);
+  void printHits(const TrackerHitVec&);
+
   lcio::LCCollection *GetCollection(lcio::LCEvent *evt, std::string colName);
 
   std::string _input_track_col_name;
@@ -78,6 +81,7 @@ protected:
   double _magneticField = 0.0;
   bool _extrapolateForward = true;
 
+  double _minPt = 1.0;
   double _maxDeltaTheta = 0.0, _maxDeltaPhi = 0.0, _maxDeltaPt = 0.0;
 
   bool _mergeSplitTracks = false;
@@ -95,5 +99,6 @@ protected:
 };
 
 bool sort_by_r(EVENT::TrackerHit*, EVENT::TrackerHit*);
+//bool sort_by_z(EVENT::TrackerHit*, EVENT::TrackerHit*);
 
 #endif

--- a/source/Refitting/include/ClonesAndSplitTracksFinder.h
+++ b/source/Refitting/include/ClonesAndSplitTracksFinder.h
@@ -2,7 +2,6 @@
 #define ClonesAndSplitTracksFinder_h 1
 
 #include <marlin/Processor.h>
-#include "TruthTrackFinder.h"
 
 #include <UTIL/BitField64.h>
 

--- a/source/Refitting/include/ClonesAndSplitTracksFinder.h
+++ b/source/Refitting/include/ClonesAndSplitTracksFinder.h
@@ -74,9 +74,6 @@ protected:
   // Contains the whole clone skimming procedure (calls bestInClones and filterClonesAndMergedTracks(bool true))
   void removeClones(EVENT::TrackVec&, LCCollection*&);
 
-  void printHits(const Track*);
-  void printHits(const TrackerHitVec&);
-
   lcio::LCCollection *GetCollection(lcio::LCEvent *evt, std::string colName);
 
   std::string _input_track_col_name;
@@ -109,8 +106,5 @@ protected:
   std::shared_ptr<UTIL::BitField64> _encoder{};
 
 };
-
-bool sort_by_r(EVENT::TrackerHit*, EVENT::TrackerHit*);
-//bool sort_by_z(EVENT::TrackerHit*, EVENT::TrackerHit*);
 
 #endif

--- a/source/Refitting/include/ClonesAndSplitTracksFinder.h
+++ b/source/Refitting/include/ClonesAndSplitTracksFinder.h
@@ -60,13 +60,13 @@ protected:
   void mergeSplitTracks(std::unique_ptr<LCCollectionVec>&, LCCollection*&, EVENT::TrackVec&);
 
   // Calculate significance in pt for two candidate clones
-  double calculateSignificancePt(Track *, Track *);
+  double calculateSignificancePt(const Track *, const Track *);
 
   // Calculate significance in phi for two candidate clones
-  double calculateSignificancePhi(Track *, Track *);
+  double calculateSignificancePhi(const Track *, const Track *);
 
   // Calculate significance in tanLambda for two candidate clones
-  double calculateSignificanceTanLambda(Track *, Track *);
+  double calculateSignificanceTanLambda(const Track *, const Track *);
 
   // Calculate significance for two candidate clones
   double calculateSignificance(const double firstPar, const double secondPar, const double firstPar_sigma, const double secondPar_sigma );

--- a/source/Refitting/include/ClonesAndSplitTracksFinder.h
+++ b/source/Refitting/include/ClonesAndSplitTracksFinder.h
@@ -60,6 +60,12 @@ protected:
   // Contains the whole merging procedure (calls filterClonesAndMergedTracks(bool false) and mergeAndFit)
   void mergeSplitTracks(std::unique_ptr<LCCollectionVec>&, LCCollection*&, EVENT::TrackVec&);
 
+  // Calculate significance in pt for two candidate clones
+  double calculateSignificancePt(Track *, Track *);
+
+  // Calculate significance in phi for two candidate clones
+  double calculateSignificancePhi(Track *, Track *);
+
   // Contains the whole clone skimming procedure (calls bestInClones and filterClonesAndMergedTracks(bool true))
   void removeClones(EVENT::TrackVec&, LCCollection*&);
 

--- a/source/Refitting/include/ClonesAndSplitTracksFinder.h
+++ b/source/Refitting/include/ClonesAndSplitTracksFinder.h
@@ -2,6 +2,7 @@
 #define ClonesAndSplitTracksFinder_h 1
 
 #include <marlin/Processor.h>
+#include "TruthTrackFinder.h"
 
 #include <UTIL/BitField64.h>
 

--- a/source/Refitting/include/TruthTrackFinder.h
+++ b/source/Refitting/include/TruthTrackFinder.h
@@ -95,9 +95,6 @@ class TruthTrackFinder : public Processor {
 		
 } ;
 
-bool sort_by_radius(EVENT::TrackerHit*, EVENT::TrackerHit*);
-
-
 #endif
 
 

--- a/source/Refitting/src/ClonesAndSplitTracksFinder.cc
+++ b/source/Refitting/src/ClonesAndSplitTracksFinder.cc
@@ -368,7 +368,6 @@ void ClonesAndSplitTracksFinder::mergeSplitTracks(std::unique_ptr<LCCollectionVe
 	  }
 
 	  streamlog_out( DEBUG5 ) << " -> phi significance = " << significancePhi << " with cut at " << _maxSignificancePhi << std::endl;
-	  //Has to be fixed at some point as it doesn't work at phi ~ +- pi
 	  if(significancePhi < _maxSignificancePhi){
 	    isCloseInPhi = true;
             streamlog_out( DEBUG5 ) << " Tracks are close in phi " << std::endl;
@@ -462,11 +461,12 @@ double ClonesAndSplitTracksFinder::calculateSignificancePhi(Track * first, Track
   double significance = 10E5;
   float phiFirst = first->getPhi();
   float phiSecond = second->getPhi();
+  float deltaPhi = (M_PI - std::abs(std::abs(phiFirst - phiSecond) - M_PI));
 
   const float sigmaPhiFirst = sqrt(first->getCovMatrix()[2]);
   const float sigmaPhiSecond = sqrt(second->getCovMatrix()[2]);
 
-  significance = calculateSignificance(phiFirst, phiSecond, sigmaPhiFirst, sigmaPhiSecond);
+  significance = calculateSignificance(deltaPhi, 0.0, sigmaPhiFirst, sigmaPhiSecond);
 
   return significance;
 

--- a/source/Refitting/src/ClonesAndSplitTracksFinder.cc
+++ b/source/Refitting/src/ClonesAndSplitTracksFinder.cc
@@ -85,17 +85,17 @@ ClonesAndSplitTracksFinder::ClonesAndSplitTracksFinder() : Processor("ClonesAndS
 			     double(1.0));
 
   registerProcessorParameter("maxSignificanceTheta",
-			     "maximum theta separation for merging (in deg)",
+			     "maximum significance separation in tanLambda",
 			     _maxSignificanceTheta,
 			     double(0.59));
 
   registerProcessorParameter("maxSignificancePhi",
-			     "maximum phi separation for merging (in deg)",
+			     "maximum significance separation in phi",
 			     _maxSignificancePhi,
 			     double(0.99));
 
   registerProcessorParameter("maxSignificancePt",
-			     "maximum pt separation for merging (in GeV/c)",
+			     "maximum significance separation in pt",
 			     _maxSignificancePt,
 			     double(0.69));
 
@@ -379,20 +379,20 @@ void ClonesAndSplitTracksFinder::mergeSplitTracks(std::unique_ptr<LCCollectionVe
           double significancePhi = calculateSignificancePhi(track_i, track_j);
           double significancePt = calculateSignificancePt(track_i, track_j);
 
-	  streamlog_out( DEBUG5 ) << " -> tanLambda significance = " << significanceTanLambda << " with cut at " << _maxSignificanceTheta << std::endl;
+	  streamlog_out( DEBUG2 ) << " -> tanLambda significance = " << significanceTanLambda << " with cut at " << _maxSignificanceTheta << std::endl;
 	  if(significanceTanLambda < _maxSignificanceTheta){
 	    isCloseInTheta = true;
             streamlog_out( DEBUG5 ) << " Tracks are close in theta " << std::endl;
 	  }
 
-	  streamlog_out( DEBUG5 ) << " -> phi significance = " << significancePhi << " with cut at " << _maxSignificancePhi << std::endl;
+	  streamlog_out( DEBUG2 ) << " -> phi significance = " << significancePhi << " with cut at " << _maxSignificancePhi << std::endl;
 	  //Has to be fixed at some point as it doesn't work at phi ~ +- pi
 	  if(significancePhi < _maxSignificancePhi){
 	    isCloseInPhi = true;
             streamlog_out( DEBUG5 ) << " Tracks are close in phi " << std::endl;
 	  }
 
-	  streamlog_out( DEBUG5 ) << " -> pt significance = " << significancePt << " with cut at " << _maxSignificancePt << std::endl;
+	  streamlog_out( DEBUG2 ) << " -> pt significance = " << significancePt << " with cut at " << _maxSignificancePt << std::endl;
 	  if(significancePt < _maxSignificancePt){
 	    isCloseInPt = true;
             streamlog_out( DEBUG5 ) << " Tracks are close in pt  " << std::endl;
@@ -427,17 +427,9 @@ void ClonesAndSplitTracksFinder::mergeSplitTracks(std::unique_ptr<LCCollectionVe
 
       } // end loop on jTracks
 
-      streamlog_out( DEBUG5 ) << " Track merged have iter: [" << std::endl;
-      for(auto dupl : iter_duplicates){
-        streamlog_out( DEBUG5 ) << dupl << ", ";
-      }
-      streamlog_out( DEBUG5 ) << "]" << std::endl;
-
       // Track was already found as duplicate
       const bool is_in = iter_duplicates.find(iTrack) != iter_duplicates.end();
-
       if(countMergingPartners == 0 && !is_in){  // if track_i has no merging partner, store it in the output vec
-        streamlog_out( DEBUG5 ) << " Track #" << iTrack << ": pt = " << pt_i << ", theta = " << theta_i << ", phi = " << phi_i << std::endl;
         streamlog_out( DEBUG5 ) << " Track #" << iTrack << " has no merging partners, so TRACK STORED." << std::endl;
 
 	TrackImpl *trackFinal = new TrackImpl;
@@ -472,19 +464,12 @@ double ClonesAndSplitTracksFinder::calculateSignificancePt(Track * first, Track 
   double ptFirst = 0.3 * _magneticField / (fabs(first->getOmega()*1000.));
   double ptSecond = 0.3 * _magneticField / (fabs(second->getOmega()*1000.));
 
-  streamlog_out( DEBUG5 ) << " - First track  : pt    = " << ptFirst << std::endl;
-  streamlog_out( DEBUG5 ) << " - Second track : pt    = " << ptSecond << std::endl;
-
   const float sigmaPOverPFirst  = sqrt(first->getCovMatrix()[5])/fabs(omegaFirst);
   const float sigmaPOverPSecond = sqrt(second->getCovMatrix()[5])/fabs(omegaSecond);
   const float sigmaPtFirst = ptFirst*sigmaPOverPFirst;
   const float sigmaPtSecond = ptSecond*sigmaPOverPSecond;
 
-  streamlog_out( DEBUG5 ) << " - First track  :  sigmaPtFirst  = " << sigmaPtFirst << std::endl;
-  streamlog_out( DEBUG5 ) << " - Second track :  sigmaPtSecond = " << sigmaPtSecond << std::endl;
-
   significance = calculateSignificance(ptFirst, ptSecond, sigmaPtFirst, sigmaPtSecond);
-  streamlog_out( DEBUG5 ) << " >> significance on pt = " << significance << std::endl;
 
   return significance;
 
@@ -496,16 +481,10 @@ double ClonesAndSplitTracksFinder::calculateSignificancePhi(Track * first, Track
   float phiFirst = first->getPhi();
   float phiSecond = second->getPhi();
 
-  streamlog_out( DEBUG5 ) << " - First track  : phi   = " << phiFirst << std::endl;
-  streamlog_out( DEBUG5 ) << " - Second track : phi   = " << phiSecond << std::endl;
-
   const float sigmaPhiFirst = sqrt(first->getCovMatrix()[2]);
   const float sigmaPhiSecond = sqrt(second->getCovMatrix()[2]);
-  streamlog_out( DEBUG5 ) << " - First track  :  sigmaPhi      = " << sigmaPhiFirst << std::endl;
-  streamlog_out( DEBUG5 ) << " - Second track :  sigmaPhi      = " << sigmaPhiSecond << std::endl;
 
   significance = calculateSignificance(phiFirst, phiSecond, sigmaPhiFirst, sigmaPhiSecond);
-  streamlog_out( DEBUG5 ) << " >> significance on phi = " << significance << std::endl;
 
   return significance;
 
@@ -517,16 +496,10 @@ double ClonesAndSplitTracksFinder::calculateSignificanceTanLambda(Track * first,
   float tanLambdaFirst = first->getTanLambda();
   float tanLambdaSecond = second->getTanLambda();
 
-  streamlog_out( DEBUG5 ) << " - First track  : tanLambda   = " << tanLambdaFirst << std::endl;
-  streamlog_out( DEBUG5 ) << " - Second track : tanLambda   = " << tanLambdaSecond << std::endl;
-
   const float sigmaTanLambdaFirst = sqrt(first->getCovMatrix()[14]);
   const float sigmaTanLambdaSecond = sqrt(second->getCovMatrix()[14]);
-  streamlog_out( DEBUG5 ) << " - First track  :  sigmaTanLambda      = " << sigmaTanLambdaFirst << std::endl;
-  streamlog_out( DEBUG5 ) << " - Second track :  sigmaTanLambda      = " << sigmaTanLambdaSecond << std::endl;
 
   significance = calculateSignificance(tanLambdaFirst, tanLambdaSecond, sigmaTanLambdaFirst, sigmaTanLambdaSecond);
-  streamlog_out( DEBUG5 ) << " >> significance on tanLambda = " << significance << std::endl;
 
   return significance;
 

--- a/source/Refitting/src/ClonesAndSplitTracksFinder.cc
+++ b/source/Refitting/src/ClonesAndSplitTracksFinder.cc
@@ -436,9 +436,8 @@ void ClonesAndSplitTracksFinder::mergeSplitTracks(std::unique_ptr<LCCollectionVe
 
 }
 
-double ClonesAndSplitTracksFinder::calculateSignificancePt(Track * first, Track * second){
+double ClonesAndSplitTracksFinder::calculateSignificancePt(const Track * first, const Track * second){
 
-  double significance = 10E5;
   float omegaFirst = first->getOmega();
   float omegaSecond = second->getOmega();
 
@@ -450,15 +449,14 @@ double ClonesAndSplitTracksFinder::calculateSignificancePt(Track * first, Track 
   const float sigmaPtFirst = ptFirst*sigmaPOverPFirst;
   const float sigmaPtSecond = ptSecond*sigmaPOverPSecond;
 
-  significance = calculateSignificance(ptFirst, ptSecond, sigmaPtFirst, sigmaPtSecond);
+  const double significance = calculateSignificance(ptFirst, ptSecond, sigmaPtFirst, sigmaPtSecond);
 
   return significance;
 
 }
 
-double ClonesAndSplitTracksFinder::calculateSignificancePhi(Track * first, Track * second){
+double ClonesAndSplitTracksFinder::calculateSignificancePhi(const Track * first, const Track * second){
 
-  double significance = 10E5;
   float phiFirst = first->getPhi();
   float phiSecond = second->getPhi();
   float deltaPhi = (M_PI - std::abs(std::abs(phiFirst - phiSecond) - M_PI));
@@ -466,22 +464,21 @@ double ClonesAndSplitTracksFinder::calculateSignificancePhi(Track * first, Track
   const float sigmaPhiFirst = sqrt(first->getCovMatrix()[2]);
   const float sigmaPhiSecond = sqrt(second->getCovMatrix()[2]);
 
-  significance = calculateSignificance(deltaPhi, 0.0, sigmaPhiFirst, sigmaPhiSecond);
+  const double significance = calculateSignificance(deltaPhi, 0.0, sigmaPhiFirst, sigmaPhiSecond);
 
   return significance;
 
 }
 
-double ClonesAndSplitTracksFinder::calculateSignificanceTanLambda(Track * first, Track * second){
+double ClonesAndSplitTracksFinder::calculateSignificanceTanLambda(const Track * first, const Track * second){
 
-  double significance = 10E5;
   float tanLambdaFirst = first->getTanLambda();
   float tanLambdaSecond = second->getTanLambda();
 
   const float sigmaTanLambdaFirst = sqrt(first->getCovMatrix()[14]);
   const float sigmaTanLambdaSecond = sqrt(second->getCovMatrix()[14]);
 
-  significance = calculateSignificance(tanLambdaFirst, tanLambdaSecond, sigmaTanLambdaFirst, sigmaTanLambdaSecond);
+  const double significance = calculateSignificance(tanLambdaFirst, tanLambdaSecond, sigmaTanLambdaFirst, sigmaTanLambdaSecond);
 
   return significance;
 
@@ -489,7 +486,7 @@ double ClonesAndSplitTracksFinder::calculateSignificanceTanLambda(Track * first,
 
 double ClonesAndSplitTracksFinder::calculateSignificance(const double firstPar, const double secondPar, const double firstPar_sigma, const double secondPar_sigma ){
 
-  const float delta = fabs( firstPar- secondPar );
+  const float delta = fabs( firstPar - secondPar );
   const float sigmaDelta = sqrt( firstPar_sigma*firstPar_sigma + secondPar_sigma*secondPar_sigma );
 
   return delta/sigmaDelta;

--- a/source/Refitting/src/ClonesAndSplitTracksFinder.cc
+++ b/source/Refitting/src/ClonesAndSplitTracksFinder.cc
@@ -8,8 +8,8 @@
 #include <MarlinTrk/Factory.h>
 #include <MarlinTrk/IMarlinTrack.h>
 #include <MarlinTrk/MarlinTrkUtils.h>
-#include "MarlinTrk/MarlinTrkDiagnostics.h"
 #include "MarlinTrk/IMarlinTrkSystem.h"
+#include "MarlinTrk/MarlinTrkDiagnostics.h"
 
 #include <marlinutil/GeometryUtil.h>
 
@@ -24,8 +24,8 @@
 #include <UTIL/LCTrackerConf.h>
 #include <UTIL/Operators.h>
 
-#include "DD4hep/Detector.h"
 #include "DD4hep/DD4hepUnits.h"
+#include "DD4hep/Detector.h"
 #include "DDRec/SurfaceManager.h"
 
 #include <algorithm>
@@ -37,127 +37,94 @@ using namespace std;
 ClonesAndSplitTracksFinder aClonesAndSplitTracksFinder;
 
 ClonesAndSplitTracksFinder::ClonesAndSplitTracksFinder() : Processor("ClonesAndSplitTracksFinder") {
-
   // modify processor description
-  _description = "ClonesAndSplitTracksFinder takes the track collection, checks for doubles and merges them in an output track collection";
+  _description =
+      "ClonesAndSplitTracksFinder takes the track collection, checks for doubles and merges them in an output track "
+      "collection";
 
   // register steering parameters: name, description, class-variable, default
   // value
 
-  registerInputCollection(LCIO::TRACK, 
-			  "InputTrackCollectionName",
-                          "Name of the input track collection",
-                          _input_track_col_name, 
-			  std::string("SiTracks"));
+  registerInputCollection(LCIO::TRACK, "InputTrackCollectionName", "Name of the input track collection",
+                          _input_track_col_name, std::string("SiTracks"));
 
-  registerOutputCollection(LCIO::TRACK, 
-			   "OutputTrackCollectionName",
-                           "Name of the output track collection",
-                           _output_track_col_name, 
-			   std::string("SiTracksMerged"));
+  registerOutputCollection(LCIO::TRACK, "OutputTrackCollectionName", "Name of the output track collection",
+                           _output_track_col_name, std::string("SiTracksMerged"));
 
-  registerProcessorParameter("MultipleScatteringOn",
-                             "Use MultipleScattering in Fit", 
-			     _MSOn,
-                             bool(true));
+  registerProcessorParameter("MultipleScatteringOn", "Use MultipleScattering in Fit", _MSOn, bool(true));
 
-  registerProcessorParameter("EnergyLossOn", 
-			     "Use Energy Loss in Fit", 
-			     _ElossOn,
-                             bool(true));
+  registerProcessorParameter("EnergyLossOn", "Use Energy Loss in Fit", _ElossOn, bool(true));
 
-  registerProcessorParameter("SmoothOn", 
-			     "Smooth All Measurement Sites in Fit",
-                             _SmoothOn, 
-			     bool(false));
+  registerProcessorParameter("SmoothOn", "Smooth All Measurement Sites in Fit", _SmoothOn, bool(false));
 
   registerProcessorParameter("extrapolateForward",
                              "if true extrapolation in the forward direction "
                              "(in-out), otherwise backward (out-in)",
-                             _extrapolateForward, 
-			     bool(true));
+                             _extrapolateForward, bool(true));
 
-  registerProcessorParameter("minTrackPt",
-			     "minimum track pt for merging (in GeV/c)",
-			     _minPt,
-			     double(1.0));
+  registerProcessorParameter("minTrackPt", "minimum track pt for merging (in GeV/c)", _minPt, double(1.0));
 
-  registerProcessorParameter("maxSignificanceTheta",
-			     "maximum significance separation in tanLambda",
-			     _maxSignificanceTheta,
-			     double(3.0));
+  registerProcessorParameter("maxSignificanceTheta", "maximum significance separation in tanLambda", _maxSignificanceTheta,
+                             double(3.0));
 
-  registerProcessorParameter("maxSignificancePhi",
-			     "maximum significance separation in phi",
-			     _maxSignificancePhi,
-			     double(3.0));
+  registerProcessorParameter("maxSignificancePhi", "maximum significance separation in phi", _maxSignificancePhi,
+                             double(3.0));
 
-  registerProcessorParameter("maxSignificancePt",
-			     "maximum significance separation in pt",
-			     _maxSignificancePt,
-			     double(2.0));
+  registerProcessorParameter("maxSignificancePt", "maximum significance separation in pt", _maxSignificancePt, double(2.0));
 
-  registerProcessorParameter("mergeSplitTracks",
-			     "if true, the merging of split tracks is performed",
-			     _mergeSplitTracks,
-			     bool(false));
-
+  registerProcessorParameter("mergeSplitTracks", "if true, the merging of split tracks is performed", _mergeSplitTracks,
+                             bool(false));
 }
 
 void ClonesAndSplitTracksFinder::init() {
-
   // usually a good idea to
   printParameters();
 
   _trksystem = MarlinTrk::Factory::createMarlinTrkSystem("DDKalTest", nullptr, "");
-  
+
   _magneticField = MarlinUtil::getBzAtOrigin();
   ///////////////////////////////
 
-  _encoder = std::make_shared<UTIL::BitField64>(
-      lcio::LCTrackerCellID::encoding_string());
+  _encoder = std::make_shared<UTIL::BitField64>(lcio::LCTrackerCellID::encoding_string());
 
   if (not _trksystem) {
-    throw EVENT::Exception(
-        "Cannot initialize MarlinTrkSystem of Type: DDKalTest");
+    throw EVENT::Exception("Cannot initialize MarlinTrkSystem of Type: DDKalTest");
   }
 
   _trksystem->setOption(MarlinTrk::IMarlinTrkSystem::CFG::useQMS, _MSOn);
   _trksystem->setOption(MarlinTrk::IMarlinTrkSystem::CFG::usedEdx, _ElossOn);
-  _trksystem->setOption(MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing,
-                        _SmoothOn);
+  _trksystem->setOption(MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing, _SmoothOn);
   _trksystem->init();
-      
+
   // Put default values for track fitting
-  _initialTrackError_d0 = 1.e6;
-  _initialTrackError_phi0 = 1.e2;
+  _initialTrackError_d0    = 1.e6;
+  _initialTrackError_phi0  = 1.e2;
   _initialTrackError_omega = 1.e-4;
-  _initialTrackError_z0 = 1.e6;
-  _initialTrackError_tanL = 1.e2;
-  _maxChi2perHit = 1.e2;
-  
+  _initialTrackError_z0    = 1.e6;
+  _initialTrackError_tanL  = 1.e2;
+  _maxChi2perHit           = 1.e2;
+
   _n_run = 0;
   _n_evt = 0;
 }
 
-void ClonesAndSplitTracksFinder::processRunHeader(LCRunHeader *) { ++_n_run; }
+void ClonesAndSplitTracksFinder::processRunHeader(LCRunHeader*) { ++_n_run; }
 
-void ClonesAndSplitTracksFinder::processEvent(LCEvent *evt) {
-
-  // set the correct configuration for the tracking system for this event 
-  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useQMS>       mson( _trksystem,  _MSOn ) ;
-  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::usedEdx>      elosson( _trksystem,_ElossOn) ;
-  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing> smoothon( _trksystem,_SmoothOn) ;
+void ClonesAndSplitTracksFinder::processEvent(LCEvent* evt) {
+  // set the correct configuration for the tracking system for this event
+  MarlinTrk::TrkSysConfig<MarlinTrk::IMarlinTrkSystem::CFG::useQMS>       mson(_trksystem, _MSOn);
+  MarlinTrk::TrkSysConfig<MarlinTrk::IMarlinTrkSystem::CFG::usedEdx>      elosson(_trksystem, _ElossOn);
+  MarlinTrk::TrkSysConfig<MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing> smoothon(_trksystem, _SmoothOn);
 
   ++_n_evt;
 
   // get input collection and relations
-  LCCollection *input_track_col = this->GetCollection(evt, _input_track_col_name);
+  LCCollection* input_track_col = this->GetCollection(evt, _input_track_col_name);
   if (not input_track_col) {
     return;
   }
   const int nTracks = input_track_col->getNumberOfElements();
-  streamlog_out(DEBUG5) << " >> ClonesAndSplitTracksFinder starts with " << nTracks << " tracks." << std::endl; 
+  streamlog_out(DEBUG5) << " >> ClonesAndSplitTracksFinder starts with " << nTracks << " tracks." << std::endl;
 
   // establish the track collection that will be created
   auto trackVec = std::unique_ptr<LCCollectionVec>(new LCCollectionVec(LCIO::TRACK));
@@ -174,58 +141,52 @@ void ClonesAndSplitTracksFinder::processEvent(LCEvent *evt) {
   EVENT::TrackVec tracksWithoutClones;
   removeClones(tracksWithoutClones, input_track_col);
   const int ntracksWithoutClones = tracksWithoutClones.size();
-  streamlog_out(DEBUG5) << " >> ClonesAndSplitTracksFinder found " << ntracksWithoutClones << " tracks without clones." << std::endl; 
+  streamlog_out(DEBUG5) << " >> ClonesAndSplitTracksFinder found " << ntracksWithoutClones << " tracks without clones."
+                        << std::endl;
 
-  if(_mergeSplitTracks && ntracksWithoutClones > 1){
-    streamlog_out(DEBUG5) << " Try to merge tracks ..." << std::endl; 
+  if (_mergeSplitTracks && ntracksWithoutClones > 1) {
+    streamlog_out(DEBUG5) << " Try to merge tracks ..." << std::endl;
 
     //------------
     // SECOND STEP: MERGE TRACKS
     //------------
 
     mergeSplitTracks(trackVec, input_track_col, tracksWithoutClones);
-  }
-  else{
-    streamlog_out(DEBUG5) << " Not even try to merge tracks ..." << std::endl; 
-    for(UInt_t iTrk = 0; iTrk < tracksWithoutClones.size(); iTrk++){
-      TrackImpl *trackFinal = new TrackImpl;
-      fromTrackToTrackImpl(tracksWithoutClones.at(iTrk),trackFinal);
+  } else {
+    streamlog_out(DEBUG5) << " Not even try to merge tracks ..." << std::endl;
+    for (UInt_t iTrk = 0; iTrk < tracksWithoutClones.size(); iTrk++) {
+      TrackImpl* trackFinal = new TrackImpl;
+      fromTrackToTrackImpl(tracksWithoutClones.at(iTrk), trackFinal);
       trackVec->addElement(trackFinal);
-    } 
+    }
   }
-  
-  evt->addCollection(trackVec.release(), _output_track_col_name);
 
+  evt->addCollection(trackVec.release(), _output_track_col_name);
 }
 
-
-void ClonesAndSplitTracksFinder::check(LCEvent *) {}
+void ClonesAndSplitTracksFinder::check(LCEvent*) {}
 
 void ClonesAndSplitTracksFinder::end() {}
 
-LCCollection *ClonesAndSplitTracksFinder::GetCollection(LCEvent *evt, std::string colName) {
-
-  LCCollection *col = nullptr;
+LCCollection* ClonesAndSplitTracksFinder::GetCollection(LCEvent* evt, std::string colName) {
+  LCCollection* col = nullptr;
 
   try {
     col = evt->getCollection(colName.c_str());
-    streamlog_out(DEBUG3) << " --> " << colName.c_str()
-                          << " track collection found in event = " << col
-                          << " number of elements "
-                          << col->getNumberOfElements() << std::endl;
-  } catch (DataNotAvailableException &e) {
-    streamlog_out(DEBUG3) << " --> " << colName.c_str()
-                          << " collection absent in event" << std::endl;
+    streamlog_out(DEBUG3) << " --> " << colName.c_str() << " track collection found in event = " << col
+                          << " number of elements " << col->getNumberOfElements() << std::endl;
+  } catch (DataNotAvailableException& e) {
+    streamlog_out(DEBUG3) << " --> " << colName.c_str() << " collection absent in event" << std::endl;
   }
 
   return col;
 }
 
 // Function to check if two KDtracks contain several hits in common
-int ClonesAndSplitTracksFinder::overlappingHits(const Track *track1, const Track *track2) {
-  int nHitsInCommon = 0;
-  const EVENT::TrackerHitVec trackVec1 = track1->getTrackerHits();
-  const EVENT::TrackerHitVec trackVec2 = track2->getTrackerHits();
+int ClonesAndSplitTracksFinder::overlappingHits(const Track* track1, const Track* track2) {
+  int                        nHitsInCommon = 0;
+  const EVENT::TrackerHitVec trackVec1     = track1->getTrackerHits();
+  const EVENT::TrackerHitVec trackVec2     = track2->getTrackerHits();
   for (size_t hit = 0; hit < trackVec1.size(); hit++) {
     if (std::find(trackVec2.begin(), trackVec2.end(), trackVec1.at(hit)) != trackVec2.end())
       nHitsInCommon++;
@@ -234,30 +195,36 @@ int ClonesAndSplitTracksFinder::overlappingHits(const Track *track1, const Track
 }
 
 void ClonesAndSplitTracksFinder::fromTrackToTrackImpl(const Track* track, TrackImpl*& trackFinal) {
-  
-  const TrackState *ts_atOther = 0; 
-  ts_atOther = track->getTrackState(TrackState::AtOther);
-  if(ts_atOther) trackFinal->addTrackState(new TrackStateImpl(*ts_atOther));
-  const TrackState *ts_atIP = 0; 
-  ts_atIP = track->getTrackState(TrackState::AtIP);
-  if(ts_atIP) trackFinal->addTrackState(new TrackStateImpl(*ts_atIP));
-  const TrackState *ts_atFirstHit = 0; 
-  ts_atFirstHit = track->getTrackState(TrackState::AtFirstHit);
-  if(ts_atFirstHit) trackFinal->addTrackState(new TrackStateImpl(*ts_atFirstHit));
-  const TrackState *ts_atLastHit = 0; 
-  ts_atLastHit = track->getTrackState(TrackState::AtLastHit);
-  if(ts_atLastHit) trackFinal->addTrackState(new TrackStateImpl(*ts_atLastHit));
-  const TrackState *ts_atCalorimeter = 0; 
-  ts_atCalorimeter = track->getTrackState(TrackState::AtCalorimeter);
-  if(ts_atCalorimeter) trackFinal->addTrackState(new TrackStateImpl(*ts_atCalorimeter));
-  const TrackState *ts_atVertex = 0; 
-  ts_atVertex = track->getTrackState(TrackState::AtVertex);
-  if(ts_atVertex) trackFinal->addTrackState(new TrackStateImpl(*ts_atVertex));
-  const TrackState *ts_atLastLocation = 0; 
-  ts_atLastLocation = track->getTrackState(TrackState::LastLocation);
-  if(ts_atLastLocation) trackFinal->addTrackState(new TrackStateImpl(*ts_atLastLocation));
-  
-  for(UInt_t i=0; i<(track->getTrackerHits()).size(); i++){
+  const TrackState* ts_atOther = 0;
+  ts_atOther                   = track->getTrackState(TrackState::AtOther);
+  if (ts_atOther)
+    trackFinal->addTrackState(new TrackStateImpl(*ts_atOther));
+  const TrackState* ts_atIP = 0;
+  ts_atIP                   = track->getTrackState(TrackState::AtIP);
+  if (ts_atIP)
+    trackFinal->addTrackState(new TrackStateImpl(*ts_atIP));
+  const TrackState* ts_atFirstHit = 0;
+  ts_atFirstHit                   = track->getTrackState(TrackState::AtFirstHit);
+  if (ts_atFirstHit)
+    trackFinal->addTrackState(new TrackStateImpl(*ts_atFirstHit));
+  const TrackState* ts_atLastHit = 0;
+  ts_atLastHit                   = track->getTrackState(TrackState::AtLastHit);
+  if (ts_atLastHit)
+    trackFinal->addTrackState(new TrackStateImpl(*ts_atLastHit));
+  const TrackState* ts_atCalorimeter = 0;
+  ts_atCalorimeter                   = track->getTrackState(TrackState::AtCalorimeter);
+  if (ts_atCalorimeter)
+    trackFinal->addTrackState(new TrackStateImpl(*ts_atCalorimeter));
+  const TrackState* ts_atVertex = 0;
+  ts_atVertex                   = track->getTrackState(TrackState::AtVertex);
+  if (ts_atVertex)
+    trackFinal->addTrackState(new TrackStateImpl(*ts_atVertex));
+  const TrackState* ts_atLastLocation = 0;
+  ts_atLastLocation                   = track->getTrackState(TrackState::LastLocation);
+  if (ts_atLastLocation)
+    trackFinal->addTrackState(new TrackStateImpl(*ts_atLastLocation));
+
+  for (UInt_t i = 0; i < (track->getTrackerHits()).size(); i++) {
     trackFinal->addHit(track->getTrackerHits().at(i));
   }
   trackFinal->setRadiusOfInnermostHit(track->getRadiusOfInnermostHit());
@@ -265,345 +232,334 @@ void ClonesAndSplitTracksFinder::fromTrackToTrackImpl(const Track* track, TrackI
   trackFinal->setNdf(track->getNdf());
   trackFinal->setdEdx(track->getdEdx());
   trackFinal->setdEdxError(track->getdEdxError());
-
 }
 
-void ClonesAndSplitTracksFinder::removeClones(EVENT::TrackVec& tracksWithoutClones, LCCollection*& input_track_col){
-
-  streamlog_out( DEBUG8 ) << "ClonesAndSplitTracksFinder::removeClones " << std::endl;
+void ClonesAndSplitTracksFinder::removeClones(EVENT::TrackVec& tracksWithoutClones, LCCollection*& input_track_col) {
+  streamlog_out(DEBUG8) << "ClonesAndSplitTracksFinder::removeClones " << std::endl;
   const int nTracks = input_track_col->getNumberOfElements();
 
   // loop over the input tracks
 
-  std::multimap<int, std::pair<int,Track*>> candidateClones;
- 
-  for(int iTrack = 0; iTrack < nTracks; ++iTrack) { // first loop over tracks
-    int countClones = 0;
-    Track *track_i = static_cast<Track*>(input_track_col->getElementAt(iTrack));
+  std::multimap<int, std::pair<int, Track*>> candidateClones;
 
-    for(int jTrack = 0; jTrack < nTracks; ++jTrack) { // second loop over tracks
+  for (int iTrack = 0; iTrack < nTracks; ++iTrack) {  // first loop over tracks
+    int    countClones = 0;
+    Track* track_i     = static_cast<Track*>(input_track_col->getElementAt(iTrack));
 
-      Track *track_j = static_cast<Track *>(input_track_col->getElementAt(jTrack));
-      if(track_i != track_j){ // track1 != track2
+    for (int jTrack = 0; jTrack < nTracks; ++jTrack) {  // second loop over tracks
 
-	const unsigned int nOverlappingHits = overlappingHits(track_i,track_j);
-	if(nOverlappingHits >= 2){ // clones
-	  countClones++;
-	  Track* bestTrack;
-	  bestInClones(track_i,track_j,nOverlappingHits,bestTrack);
-	  candidateClones.insert(make_pair(iTrack, make_pair(jTrack,bestTrack)));
-	}
-	else{
-	  continue;
-	}
+      Track* track_j = static_cast<Track*>(input_track_col->getElementAt(jTrack));
+      if (track_i != track_j) {  // track1 != track2
 
+        const unsigned int nOverlappingHits = overlappingHits(track_i, track_j);
+        if (nOverlappingHits >= 2) {  // clones
+          countClones++;
+          Track* bestTrack;
+          bestInClones(track_i, track_j, nOverlappingHits, bestTrack);
+          candidateClones.insert(make_pair(iTrack, make_pair(jTrack, bestTrack)));
+        } else {
+          continue;
+        }
       }
 
-    } // end second track loop
+    }  // end second track loop
 
-    if(countClones == 0){
+    if (countClones == 0) {
       tracksWithoutClones.push_back(track_i);
     }
 
-  } // end first track loop
+  }  // end first track loop
 
   filterClonesAndMergedTracks(candidateClones, input_track_col, tracksWithoutClones, true);
 }
 
-void ClonesAndSplitTracksFinder::mergeSplitTracks(std::unique_ptr<LCCollectionVec>& trackVec, LCCollection*& input_track_col, EVENT::TrackVec& tracksWithoutClones){
+void ClonesAndSplitTracksFinder::mergeSplitTracks(std::unique_ptr<LCCollectionVec>& trackVec, LCCollection*& input_track_col,
+                                                  EVENT::TrackVec& tracksWithoutClones) {
+  streamlog_out(DEBUG8) << "ClonesAndSplitTracksFinder::mergeSplitTracks " << std::endl;
 
-    streamlog_out( DEBUG8 ) << "ClonesAndSplitTracksFinder::mergeSplitTracks " << std::endl;
+  std::multimap<int, std::pair<int, Track*>> mergingCandidates;
+  std::set<int> iter_duplicates;
 
-    std::multimap<int, std::pair<int, Track*>> mergingCandidates;
-    std::set<int> iter_duplicates;
+  for (UInt_t iTrack = 0; iTrack < tracksWithoutClones.size(); ++iTrack) {
+    int    countMergingPartners = 0;
+    bool   toBeMerged           = false;
+    Track* track_i              = static_cast<Track*>(tracksWithoutClones.at(iTrack));
 
-    for (UInt_t iTrack = 0; iTrack < tracksWithoutClones.size(); ++iTrack) {
-      int countMergingPartners = 0;
-      bool toBeMerged = false;
-      Track *track_i = static_cast<Track *>(tracksWithoutClones.at(iTrack));
+    double pt_i    = 0.3 * _magneticField / (fabs(track_i->getOmega()) * 1000.);
+    double theta_i = (M_PI / 2 - atan(track_i->getTanLambda())) * 180. / M_PI;
+    double phi_i   = track_i->getPhi() * 180. / M_PI;
 
-      double pt_i = 0.3 * _magneticField/ (fabs(track_i->getOmega())*1000.);
-      double theta_i = ( M_PI/2 - atan(track_i->getTanLambda()) ) * 180./M_PI;
-      double phi_i = track_i->getPhi() * 180./M_PI;
+    //Merge only tracks with min pt
+    //Try to avoid merging loopers for now
+    if (pt_i < _minPt) {
+      streamlog_out(DEBUG5) << " Track #" << iTrack << ": pt = " << pt_i << ", theta = " << theta_i << ", phi = " << phi_i
+                            << std::endl;
+      streamlog_out(DEBUG5) << " Track #" << iTrack << " does not fulfil min pt requirement." << std::endl;
+      streamlog_out(DEBUG5) << " TRACK STORED" << std::endl;
 
-      //Merge only tracks with min pt 
-      //Try to avoid merging loopers for now
-      if(pt_i < _minPt){
-        streamlog_out( DEBUG5 ) << " Track #" << iTrack << ": pt = " << pt_i << ", theta = " << theta_i << ", phi = " << phi_i << std::endl;
-        streamlog_out( DEBUG5 ) << " Track #" << iTrack << " does not fulfil min pt requirement." << std::endl;
-        streamlog_out( DEBUG5 ) << " TRACK STORED" << std::endl;
+      TrackImpl* trackFinal = new TrackImpl;
+      fromTrackToTrackImpl(track_i, trackFinal);
+      trackVec->addElement(trackFinal);
+      continue;
+    }
 
-	TrackImpl *trackFinal = new TrackImpl;
-	fromTrackToTrackImpl(track_i,trackFinal);
-	trackVec->addElement(trackFinal);
-        continue;
-      }
+    for (UInt_t jTrack = iTrack + 1; jTrack < tracksWithoutClones.size(); ++jTrack) {
+      Track* track_j        = static_cast<Track*>(tracksWithoutClones.at(jTrack));
+      bool   isCloseInTheta = false, isCloseInPhi = false, isCloseInPt = false;
 
-      for(UInt_t jTrack = iTrack+1; jTrack < tracksWithoutClones.size(); ++jTrack) {
+      if (track_j != track_i) {
+        double pt_j    = 0.3 * _magneticField / (fabs(track_j->getOmega() * 1000.));
+        double theta_j = (M_PI / 2 - atan(track_j->getTanLambda())) * 180. / M_PI;
+        double phi_j   = track_j->getPhi() * 180. / M_PI;
+        streamlog_out(DEBUG5) << " Track #" << iTrack << ": pt = " << pt_i << ", theta = " << theta_i << ", phi = " << phi_i
+                              << std::endl;
+        streamlog_out(DEBUG5) << " Track #" << jTrack << ": pt = " << pt_j << ", theta = " << theta_j << ", phi = " << phi_j
+                              << std::endl;
 
-	Track *track_j = static_cast<Track *>(tracksWithoutClones.at(jTrack));
-	bool isCloseInTheta = false, isCloseInPhi = false, isCloseInPt = false;
-    
-	if(track_j != track_i){
+        if (pt_j < _minPt) {
+          streamlog_out(DEBUG5) << " Track #" << jTrack << " does not fulfil min pt requirement. Skip. " << std::endl;
+          continue;
+        }
 
-	  double pt_j = 0.3 * _magneticField / (fabs(track_j->getOmega()*1000.));
-	  double theta_j = ( M_PI/2 - atan(track_j->getTanLambda()) ) * 180./M_PI;
-	  double phi_j = track_j->getPhi() * 180./M_PI;
-          streamlog_out( DEBUG5 ) << " Track #" << iTrack << ": pt = " << pt_i << ", theta = " << theta_i << ", phi = " << phi_i << std::endl;
-          streamlog_out( DEBUG5 ) << " Track #" << jTrack << ": pt = " << pt_j << ", theta = " << theta_j << ", phi = " << phi_j << std::endl;
+        double significanceTanLambda = calculateSignificanceTanLambda(track_i, track_j);
+        double significancePhi       = calculateSignificancePhi(track_i, track_j);
+        double significancePt        = calculateSignificancePt(track_i, track_j);
 
-          if(pt_j < _minPt){
-            streamlog_out( DEBUG5 ) << " Track #" << jTrack << " does not fulfil min pt requirement. Skip. " << std::endl;
+        streamlog_out(DEBUG5) << " -> tanLambda significance = " << significanceTanLambda << " with cut at "
+                              << _maxSignificanceTheta << std::endl;
+        if (significanceTanLambda < _maxSignificanceTheta) {
+          isCloseInTheta = true;
+          streamlog_out(DEBUG5) << " Tracks are close in theta " << std::endl;
+        }
+
+        streamlog_out(DEBUG5) << " -> phi significance = " << significancePhi << " with cut at " << _maxSignificancePhi
+                              << std::endl;
+        if (significancePhi < _maxSignificancePhi) {
+          isCloseInPhi = true;
+          streamlog_out(DEBUG5) << " Tracks are close in phi " << std::endl;
+        }
+
+        streamlog_out(DEBUG5) << " -> pt significance = " << significancePt << " with cut at " << _maxSignificancePt
+                              << std::endl;
+        if (significancePt < _maxSignificancePt) {
+          isCloseInPt = true;
+          streamlog_out(DEBUG5) << " Tracks are close in pt  " << std::endl;
+        }
+
+        if (streamlog::out.write<streamlog::DEBUG5>()) {
+          streamlog_out(DEBUG5) << " Track #" << iTrack << ": " << std::endl;
+          printHits(track_i);
+          streamlog_out(DEBUG5) << " Track #" << jTrack << ": " << std::endl;
+          printHits(track_j);
+        }
+
+        toBeMerged = isCloseInTheta && isCloseInPhi && isCloseInPt;
+
+        if (toBeMerged) {  // merging, refitting, storing in a container of mergingCandidates (multimap <*track1, pair<*track2,*trackMerged>>)
+          EVENT::Track* lcioTrkPtr = nullptr;
+          mergeAndFit(track_i, track_j, lcioTrkPtr);
+          if (not lcioTrkPtr) {
             continue;
           }
-
-          double significanceTanLambda = calculateSignificanceTanLambda(track_i, track_j);
-          double significancePhi = calculateSignificancePhi(track_i, track_j);
-          double significancePt = calculateSignificancePt(track_i, track_j);
-
-	  streamlog_out( DEBUG5 ) << " -> tanLambda significance = " << significanceTanLambda << " with cut at " << _maxSignificanceTheta << std::endl;
-	  if(significanceTanLambda < _maxSignificanceTheta){
-	    isCloseInTheta = true;
-            streamlog_out( DEBUG5 ) << " Tracks are close in theta " << std::endl;
-	  }
-
-	  streamlog_out( DEBUG5 ) << " -> phi significance = " << significancePhi << " with cut at " << _maxSignificancePhi << std::endl;
-	  if(significancePhi < _maxSignificancePhi){
-	    isCloseInPhi = true;
-            streamlog_out( DEBUG5 ) << " Tracks are close in phi " << std::endl;
-	  }
-
-	  streamlog_out( DEBUG5 ) << " -> pt significance = " << significancePt << " with cut at " << _maxSignificancePt << std::endl;
-	  if(significancePt < _maxSignificancePt){
-	    isCloseInPt = true;
-            streamlog_out( DEBUG5 ) << " Tracks are close in pt  " << std::endl;
-	  }
-
-          if( streamlog::out.write< streamlog::DEBUG5 >() ){
-            streamlog_out( DEBUG5 ) << " Track #" << iTrack << ": " << std::endl; 
-            printHits(track_i);
-            streamlog_out( DEBUG5 ) << " Track #" << jTrack << ": " << std::endl; 
-            printHits(track_j);
-          }
-
-	  toBeMerged = isCloseInTheta && isCloseInPhi && isCloseInPt;
-
-	  if(toBeMerged){  // merging, refitting, storing in a container of mergingCandidates (multimap <*track1, pair<*track2,*trackMerged>>)
-	    EVENT::Track* lcioTrkPtr=nullptr;
-	    mergeAndFit(track_i,track_j,lcioTrkPtr);
-	    if(not lcioTrkPtr) {
-	      continue;
-	    }
-	    mergingCandidates.insert(make_pair(iTrack, make_pair(jTrack,lcioTrkPtr)));
-	    countMergingPartners++;
-            iter_duplicates.insert(iTrack);
-            iter_duplicates.insert(jTrack);
-	  } 
-	  else{ // no merging conditions met
-	    continue;
-	  }
-      
-
-	}
-
-      } // end loop on jTracks
-
-      // Track was already found as duplicate
-      const bool is_in = iter_duplicates.find(iTrack) != iter_duplicates.end();
-      if(countMergingPartners == 0 && !is_in){  // if track_i has no merging partner, store it in the output vec
-        streamlog_out( DEBUG5 ) << " Track #" << iTrack << " has no merging partners, so TRACK STORED." << std::endl;
-
-	TrackImpl *trackFinal = new TrackImpl;
-	fromTrackToTrackImpl(track_i,trackFinal);
-	trackVec->addElement(trackFinal);
-
-      } else {
-        streamlog_out( DEBUG5 ) << " TRACK NOT STORED" << std::endl;
+          mergingCandidates.insert(make_pair(iTrack, make_pair(jTrack, lcioTrkPtr)));
+          countMergingPartners++;
+          iter_duplicates.insert(iTrack);
+          iter_duplicates.insert(jTrack);
+        } else {  // no merging conditions met
+          continue;
+        }
       }
-      if( countMergingPartners!=0 ) streamlog_out( DEBUG5 ) << " possible merging partners for track #" << iTrack << " are = " << countMergingPartners << std::endl;
 
-    } // end loop on iTracks
-  
-    EVENT::TrackVec finalTracks;
-    filterClonesAndMergedTracks(mergingCandidates, input_track_col, finalTracks, false);
+    }  // end loop on jTracks
 
-    for(UInt_t iTrk = 0; iTrk < finalTracks.size(); iTrk++){
-      streamlog_out( DEBUG5 ) << " TRACK STORED" << std::endl;
-      TrackImpl *trackFinal = new TrackImpl;
-      fromTrackToTrackImpl(finalTracks.at(iTrk),trackFinal);
+    // Track was already found as duplicate
+    const bool is_in = iter_duplicates.find(iTrack) != iter_duplicates.end();
+    if (countMergingPartners == 0 && !is_in) {  // if track_i has no merging partner, store it in the output vec
+      streamlog_out(DEBUG5) << " Track #" << iTrack << " has no merging partners, so TRACK STORED." << std::endl;
+
+      TrackImpl* trackFinal = new TrackImpl;
+      fromTrackToTrackImpl(track_i, trackFinal);
       trackVec->addElement(trackFinal);
-    } 
 
+    } else {
+      streamlog_out(DEBUG5) << " TRACK NOT STORED" << std::endl;
+    }
+    if (countMergingPartners != 0)
+      streamlog_out(DEBUG5) << " possible merging partners for track #" << iTrack << " are = " << countMergingPartners
+                            << std::endl;
+
+  }  // end loop on iTracks
+
+  EVENT::TrackVec finalTracks;
+  filterClonesAndMergedTracks(mergingCandidates, input_track_col, finalTracks, false);
+
+  for (UInt_t iTrk = 0; iTrk < finalTracks.size(); iTrk++) {
+    streamlog_out(DEBUG5) << " TRACK STORED" << std::endl;
+    TrackImpl* trackFinal = new TrackImpl;
+    fromTrackToTrackImpl(finalTracks.at(iTrk), trackFinal);
+    trackVec->addElement(trackFinal);
+  }
 }
 
-double ClonesAndSplitTracksFinder::calculateSignificancePt(const Track * first, const Track * second){
-
-  float omegaFirst = first->getOmega();
+double ClonesAndSplitTracksFinder::calculateSignificancePt(const Track* first, const Track* second) {
+  float omegaFirst  = first->getOmega();
   float omegaSecond = second->getOmega();
 
-  double ptFirst = 0.3 * _magneticField / (fabs(first->getOmega()*1000.));
-  double ptSecond = 0.3 * _magneticField / (fabs(second->getOmega()*1000.));
+  double ptFirst  = 0.3 * _magneticField / (fabs(first->getOmega() * 1000.));
+  double ptSecond = 0.3 * _magneticField / (fabs(second->getOmega() * 1000.));
 
-  const float sigmaPOverPFirst  = sqrt(first->getCovMatrix()[5])/fabs(omegaFirst);
-  const float sigmaPOverPSecond = sqrt(second->getCovMatrix()[5])/fabs(omegaSecond);
-  const float sigmaPtFirst = ptFirst*sigmaPOverPFirst;
-  const float sigmaPtSecond = ptSecond*sigmaPOverPSecond;
+  const float sigmaPOverPFirst  = sqrt(first->getCovMatrix()[5]) / fabs(omegaFirst);
+  const float sigmaPOverPSecond = sqrt(second->getCovMatrix()[5]) / fabs(omegaSecond);
+  const float sigmaPtFirst      = ptFirst * sigmaPOverPFirst;
+  const float sigmaPtSecond     = ptSecond * sigmaPOverPSecond;
 
   const double significance = calculateSignificance(ptFirst, ptSecond, sigmaPtFirst, sigmaPtSecond);
 
   return significance;
-
 }
 
-double ClonesAndSplitTracksFinder::calculateSignificancePhi(const Track * first, const Track * second){
-
-  float phiFirst = first->getPhi();
+double ClonesAndSplitTracksFinder::calculateSignificancePhi(const Track* first, const Track* second) {
+  float phiFirst  = first->getPhi();
   float phiSecond = second->getPhi();
-  float deltaPhi = (M_PI - std::abs(std::abs(phiFirst - phiSecond) - M_PI));
+  float deltaPhi  = (M_PI - std::abs(std::abs(phiFirst - phiSecond) - M_PI));
 
-  const float sigmaPhiFirst = sqrt(first->getCovMatrix()[2]);
+  const float sigmaPhiFirst  = sqrt(first->getCovMatrix()[2]);
   const float sigmaPhiSecond = sqrt(second->getCovMatrix()[2]);
 
   const double significance = calculateSignificance(deltaPhi, 0.0, sigmaPhiFirst, sigmaPhiSecond);
 
   return significance;
-
 }
 
-double ClonesAndSplitTracksFinder::calculateSignificanceTanLambda(const Track * first, const Track * second){
-
-  float tanLambdaFirst = first->getTanLambda();
+double ClonesAndSplitTracksFinder::calculateSignificanceTanLambda(const Track* first, const Track* second) {
+  float tanLambdaFirst  = first->getTanLambda();
   float tanLambdaSecond = second->getTanLambda();
 
-  const float sigmaTanLambdaFirst = sqrt(first->getCovMatrix()[14]);
+  const float sigmaTanLambdaFirst  = sqrt(first->getCovMatrix()[14]);
   const float sigmaTanLambdaSecond = sqrt(second->getCovMatrix()[14]);
 
-  const double significance = calculateSignificance(tanLambdaFirst, tanLambdaSecond, sigmaTanLambdaFirst, sigmaTanLambdaSecond);
+  const double significance =
+      calculateSignificance(tanLambdaFirst, tanLambdaSecond, sigmaTanLambdaFirst, sigmaTanLambdaSecond);
 
   return significance;
-
 }
 
-double ClonesAndSplitTracksFinder::calculateSignificance(const double firstPar, const double secondPar, const double firstPar_sigma, const double secondPar_sigma ){
+double ClonesAndSplitTracksFinder::calculateSignificance(const double firstPar, const double secondPar,
+                                                         const double firstPar_sigma, const double secondPar_sigma) {
+  const float delta      = fabs(firstPar - secondPar);
+  const float sigmaDelta = sqrt(firstPar_sigma * firstPar_sigma + secondPar_sigma * secondPar_sigma);
 
-  const float delta = fabs( firstPar - secondPar );
-  const float sigmaDelta = sqrt( firstPar_sigma*firstPar_sigma + secondPar_sigma*secondPar_sigma );
-
-  return delta/sigmaDelta;
+  return delta / sigmaDelta;
 }
 
-void ClonesAndSplitTracksFinder::filterClonesAndMergedTracks(std::multimap<int, std::pair<int, Track*>>& candidates, LCCollection*& inputTracks, TrackVec& trackVecFinal, bool clones){
-
+void ClonesAndSplitTracksFinder::filterClonesAndMergedTracks(std::multimap<int, std::pair<int, Track*>>& candidates,
+                                                             LCCollection*& inputTracks, TrackVec& trackVecFinal,
+                                                             bool clones) {
   std::vector<TrackerHitVec> savedHitVec;
 
-  for(const auto&iter : candidates){
-    int track_a_id = iter.first;
-    int track_b_id = iter.second.first;
-    Track* track_final = iter.second.second;
-    int countConnections = candidates.count(track_a_id);
-    bool multiConnection = (countConnections > 1);
+  for (const auto& iter : candidates) {
+    int    track_a_id       = iter.first;
+    int    track_b_id       = iter.second.first;
+    Track* track_final      = iter.second.second;
+    int    countConnections = candidates.count(track_a_id);
+    bool   multiConnection  = (countConnections > 1);
 
-    if(!multiConnection){ // if only 1 connection
+    if (!multiConnection) {  // if only 1 connection
 
-      if(clones){ // clones: compare the track pointers
-	auto it_trk = find(trackVecFinal.begin(), trackVecFinal.end(), track_final);
-	if(it_trk != trackVecFinal.end()){ // if the track is already there, do nothing
-	  continue;
-	}
-	trackVecFinal.push_back(track_final);
+      if (clones) {  // clones: compare the track pointers
+        auto it_trk = find(trackVecFinal.begin(), trackVecFinal.end(), track_final);
+        if (it_trk != trackVecFinal.end()) {  // if the track is already there, do nothing
+          continue;
+        }
+        trackVecFinal.push_back(track_final);
+      } else {  // mergeable tracks: compare the sets of tracker hits
+
+        TrackerHitVec track_final_hits = track_final->getTrackerHits();
+        bool          toBeSaved        = true;
+
+        for (const auto& hitsVec : savedHitVec) {
+          if (equal(hitsVec.begin(), hitsVec.end(), track_final_hits.begin())) {
+            toBeSaved = false;
+            break;
+          }
+        }
+
+        if (toBeSaved) {
+          savedHitVec.push_back(track_final_hits);
+          trackVecFinal.push_back(track_final);
+        } else {
+          delete track_final;
+        }
       }
-      else{ // mergeable tracks: compare the sets of tracker hits
 
-	TrackerHitVec track_final_hits = track_final->getTrackerHits();
-	bool toBeSaved = true;
+    } else {  // if more than 1 connection, clones and mergeable tracks have to be treated a little different
 
-	for(const auto &hitsVec : savedHitVec){
-	  if( equal(hitsVec.begin(), hitsVec.end(), track_final_hits.begin()) ){
-	    toBeSaved = false;
-	    break;
-	  }
-	}
+      if (clones) {  // clones
 
-	if(toBeSaved){				
-	  savedHitVec.push_back(track_final_hits);
-	  trackVecFinal.push_back(track_final);
-	}
-	else{
-	  delete track_final;
-	}
-      }
-      
+        //look at the elements with equal range. If their bestTrack is the same, store it (if not already in). If their bestTrack is different, don't store it
+        auto ret = candidates.equal_range(
+            track_a_id);  //a std::pair of iterators on the multimap [ std::pair<std::multimap<Track*,std::pair<Track*,Track*>>::iterator, std::multimap<Track*,std::pair<Track*,Track*>>::iterator> ]
+        TrackVec bestTracksMultiConnections;
+        for (std::multimap<int, std::pair<int, Track*>>::iterator it = ret.first; it != ret.second; ++it) {
+          Track* track_best = it->second.second;
+          bestTracksMultiConnections.push_back(track_best);
+        }
+        if (std::adjacent_find(bestTracksMultiConnections.begin(), bestTracksMultiConnections.end(),
+                               std::not_equal_to<Track*>()) ==
+            bestTracksMultiConnections.end()) {  //one best track with the same track key
+          auto it_trk = find(trackVecFinal.begin(), trackVecFinal.end(), bestTracksMultiConnections.at(0));
+          if (it_trk != trackVecFinal.end()) {  // if the track is already there, do nothing
+            continue;
+          }
+          trackVecFinal.push_back(bestTracksMultiConnections.at(0));
+
+        } else {  //multiple best tracks with the same track key
+          continue;
+        }
+
+      }  // end of clones
+
+      else {                 // mergeable tracks -- at the moment they are all stored (very rare anyways)
+        delete track_final;  //not using the mergedTracks, so delete it
+
+        Track* track_a = static_cast<Track*>(inputTracks->getElementAt(track_a_id));
+        Track* track_b = static_cast<Track*>(inputTracks->getElementAt(track_b_id));
+
+        auto trk1 = find(trackVecFinal.begin(), trackVecFinal.end(), track_a);
+
+        if (trk1 != trackVecFinal.end()) {  // if the track1 is already there
+          continue;
+        }
+        // otherwise store the two tracks
+        trackVecFinal.push_back(track_a);
+        trackVecFinal.push_back(track_b);
+
+      }  // end of mergeable tracks
     }
-    else{ // if more than 1 connection, clones and mergeable tracks have to be treated a little different
-
-      if(clones){ // clones
-
-	//look at the elements with equal range. If their bestTrack is the same, store it (if not already in). If their bestTrack is different, don't store it
-	auto ret = candidates.equal_range(track_a_id);  //a std::pair of iterators on the multimap [ std::pair<std::multimap<Track*,std::pair<Track*,Track*>>::iterator, std::multimap<Track*,std::pair<Track*,Track*>>::iterator> ]
-	TrackVec bestTracksMultiConnections;
-	for(std::multimap<int,std::pair<int,Track*>>::iterator it=ret.first; it!=ret.second; ++it){
-	  Track* track_best = it->second.second;
-	  bestTracksMultiConnections.push_back(track_best);
-	}
-	if(std::adjacent_find( bestTracksMultiConnections.begin(), bestTracksMultiConnections.end(), std::not_equal_to<Track*>() ) == bestTracksMultiConnections.end() ){ //one best track with the same track key
-	  auto it_trk = find(trackVecFinal.begin(),trackVecFinal.end(),bestTracksMultiConnections.at(0));
-	  if(it_trk != trackVecFinal.end()){ // if the track is already there, do nothing
-	    continue;
-	  }
-	  trackVecFinal.push_back(bestTracksMultiConnections.at(0));
-	
-	}
-	else{ //multiple best tracks with the same track key
-	  continue;
-	}
-
-      } // end of clones
-	
-      else{ // mergeable tracks -- at the moment they are all stored (very rare anyways)
-	delete track_final; //not using the mergedTracks, so delete it
-
-	Track *track_a = static_cast<Track*>(inputTracks->getElementAt(track_a_id));
-        Track *track_b = static_cast<Track*>(inputTracks->getElementAt(track_b_id));
-
-        auto trk1 = find(trackVecFinal.begin(),trackVecFinal.end(),track_a);
-	
-	if(trk1 != trackVecFinal.end()){  // if the track1 is already there
-	  continue;
-	}
-	// otherwise store the two tracks
-	trackVecFinal.push_back(track_a);
-	trackVecFinal.push_back(track_b);
-
-	
-    } // end of mergeable tracks	     
-	
   }
 }
 
-}
-
 void ClonesAndSplitTracksFinder::mergeAndFit(Track* track_i, Track* track_j, Track*& lcioTrkPtr) {
-  
-  streamlog_out( DEBUG8 ) << "ClonesAndSplitTracksFinder::mergeAndFit " << std::endl;
+  streamlog_out(DEBUG8) << "ClonesAndSplitTracksFinder::mergeAndFit " << std::endl;
   EVENT::TrackerHitVec trkHits_i = track_i->getTrackerHits();
   EVENT::TrackerHitVec trkHits_j = track_j->getTrackerHits();
 
   EVENT::TrackerHitVec trkHits;
-  for(UInt_t iHits=0; iHits<trkHits_i.size();iHits++){
+  for (UInt_t iHits = 0; iHits < trkHits_i.size(); iHits++) {
     trkHits.push_back(trkHits_i.at(iHits));
   }
   //Remove common hits while filling for the second track
-  for(UInt_t jHits=0; jHits<trkHits_j.size();jHits++){
-    if(std::find(trkHits.begin(), trkHits.end(), trkHits_j.at(jHits)) != trkHits.end() ){
-      streamlog_out( DEBUG8 ) << " This hit is already in the track" << std::endl;
+  for (UInt_t jHits = 0; jHits < trkHits_j.size(); jHits++) {
+    if (std::find(trkHits.begin(), trkHits.end(), trkHits_j.at(jHits)) != trkHits.end()) {
+      streamlog_out(DEBUG8) << " This hit is already in the track" << std::endl;
       continue;
     } else {
       trkHits.push_back(trkHits_j.at(jHits));
     }
   }
-  std::sort(trkHits.begin(),trkHits.end(),sort_by_radius);
-  if( streamlog::out.write< streamlog::DEBUG5 >() ){
-    streamlog_out( DEBUG8 ) << " Hits in track to be merged: " << std::endl;
+  std::sort(trkHits.begin(), trkHits.end(), sort_by_radius);
+  if (streamlog::out.write<streamlog::DEBUG5>()) {
+    streamlog_out(DEBUG8) << " Hits in track to be merged: " << std::endl;
     printHits(trkHits);
   }
 
@@ -612,28 +568,27 @@ void ClonesAndSplitTracksFinder::mergeAndFit(Track* track_i, Track* track_j, Tra
   auto marlin_trk = std::unique_ptr<MarlinTrk::IMarlinTrack>(_trksystem->createTrack());
 
   // Make an initial covariance matrix with very broad default values
-  EVENT::FloatVec covMatrix (15,0); // Size 15, filled with 0s
-  covMatrix[0]  = ( _initialTrackError_d0    ); //sigma_d0^2
-  covMatrix[2]  = ( _initialTrackError_phi0  ); //sigma_phi0^2
-  covMatrix[5]  = ( _initialTrackError_omega ); //sigma_omega^2
-  covMatrix[9]  = ( _initialTrackError_z0    ); //sigma_z0^2
-  covMatrix[14] = ( _initialTrackError_tanL  ); //sigma_tanl^2
+  EVENT::FloatVec covMatrix(15, 0);            // Size 15, filled with 0s
+  covMatrix[0]  = (_initialTrackError_d0);     //sigma_d0^2
+  covMatrix[2]  = (_initialTrackError_phi0);   //sigma_phi0^2
+  covMatrix[5]  = (_initialTrackError_omega);  //sigma_omega^2
+  covMatrix[9]  = (_initialTrackError_z0);     //sigma_z0^2
+  covMatrix[14] = (_initialTrackError_tanL);   //sigma_tanl^2
 
-  const bool direction = _extrapolateForward
-                             ? MarlinTrk::IMarlinTrack::forward
-                             : MarlinTrk::IMarlinTrack::backward;
+  const bool direction = _extrapolateForward ? MarlinTrk::IMarlinTrack::forward : MarlinTrk::IMarlinTrack::backward;
 
-  int fit_status = MarlinTrk::createFinalisedLCIOTrack(marlin_trk.get(), trkHits, mergedTrack.get(), direction, covMatrix, _magneticField, _maxChi2perHit);
+  int fit_status = MarlinTrk::createFinalisedLCIOTrack(marlin_trk.get(), trkHits, mergedTrack.get(), direction, covMatrix,
+                                                       _magneticField, _maxChi2perHit);
 
-  if(fit_status != 0){
+  if (fit_status != 0) {
     streamlog_out(DEBUG4) << "Fit failed with error status " << fit_status << std::endl;
     return;
   }
-  streamlog_out( DEBUG8 ) << " >> Fit not failed ! " << std::endl;
-  
+  streamlog_out(DEBUG8) << " >> Fit not failed ! " << std::endl;
+
   // fit finished - get hits in the fit
-  std::vector<std::pair<EVENT::TrackerHit *, double>> hits_in_fit;
-  std::vector<std::pair<EVENT::TrackerHit *, double>> outliers;
+  std::vector<std::pair<EVENT::TrackerHit*, double>> hits_in_fit;
+  std::vector<std::pair<EVENT::TrackerHit*, double>> outliers;
 
   // remember the hits are ordered in the order in which they were fitted
 
@@ -645,7 +600,7 @@ void ClonesAndSplitTracksFinder::mergeAndFit(Track* track_i, Track* track_j, Tra
 
   marlin_trk->getOutliers(outliers);
 
-  std::vector<TrackerHit *> all_hits;
+  std::vector<TrackerHit*> all_hits;
   all_hits.reserve(hits_in_fit.size() + outliers.size());
 
   for (unsigned ihit = 0; ihit < hits_in_fit.size(); ++ihit) {
@@ -657,12 +612,12 @@ void ClonesAndSplitTracksFinder::mergeAndFit(Track* track_i, Track* track_j, Tra
   }
 
   UTIL::BitField64 encoder2(lcio::LCTrackerCellID::encoding_string());
-  encoder2.reset(); // reset to 0
+  encoder2.reset();  // reset to 0
   MarlinTrk::addHitNumbersToTrack(mergedTrack.get(), all_hits, false, encoder2);
   MarlinTrk::addHitNumbersToTrack(mergedTrack.get(), hits_in_fit, true, encoder2);
 
-  if( streamlog::out.write< streamlog::DEBUG5 >() ){
-    streamlog_out( DEBUG5 ) << " Merged track : " << std::endl; 
+  if (streamlog::out.write<streamlog::DEBUG5>()) {
+    streamlog_out(DEBUG5) << " Merged track : " << std::endl;
     printHits(&*mergedTrack);
   }
 
@@ -670,7 +625,6 @@ void ClonesAndSplitTracksFinder::mergeAndFit(Track* track_i, Track* track_j, Tra
 }
 
 void ClonesAndSplitTracksFinder::bestInClones(Track* track_a, Track* track_b, int nOverlappingHits, Track*& bestTrack) {
-
   // This function compares two tracks which have a certain number of overlapping hits and returns the best track
   // The best track is chosen based on length (in terms of number of hits) and chi2/ndf requirements
   // In general, the longest track is preferred. When clones have same length, the one with best chi2/ndf is chosen
@@ -681,28 +635,22 @@ void ClonesAndSplitTracksFinder::bestInClones(Track* track_a, Track* track_b, in
   int trackerHit_a_size = trackerHit_a.size();
   int trackerHit_b_size = trackerHit_b.size();
 
-  double b_chi2 = track_b->getChi2()/track_b->getNdf();
-  double a_chi2 = track_a->getChi2()/track_a->getNdf();
+  double b_chi2 = track_b->getChi2() / track_b->getNdf();
+  double a_chi2 = track_a->getChi2() / track_a->getNdf();
 
-  if(nOverlappingHits == trackerHit_a_size){ // if the second track is the first track + segment
-     bestTrack = track_b;
-  }
-  else if(nOverlappingHits == trackerHit_b_size){ // if the second track is a subtrack of the first track
-    bestTrack = track_a; 
-  }
-  else if(trackerHit_b_size == trackerHit_a_size){ // if the two tracks have the same length
-    if(b_chi2 <= a_chi2){
+  if (nOverlappingHits == trackerHit_a_size) {  // if the second track is the first track + segment
+    bestTrack = track_b;
+  } else if (nOverlappingHits == trackerHit_b_size) {  // if the second track is a subtrack of the first track
+    bestTrack = track_a;
+  } else if (trackerHit_b_size == trackerHit_a_size) {  // if the two tracks have the same length
+    if (b_chi2 <= a_chi2) {
       bestTrack = track_b;
-    }
-    else{
+    } else {
       bestTrack = track_a;
     }
-  }
-  else if(trackerHit_b_size > trackerHit_a_size){ // if the second track is longer
-    bestTrack = track_b; 
-  }
-  else if(trackerHit_b_size < trackerHit_a_size){ // if the second track is shorter
+  } else if (trackerHit_b_size > trackerHit_a_size) {  // if the second track is longer
+    bestTrack = track_b;
+  } else if (trackerHit_b_size < trackerHit_a_size) {  // if the second track is shorter
     bestTrack = track_a;
   }
-
 }

--- a/source/Refitting/src/TruthTrackFinder.cc
+++ b/source/Refitting/src/TruthTrackFinder.cc
@@ -1,5 +1,6 @@
 /* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 #include "TruthTrackFinder.h"
+#include "HitsSorterAndDebugger.h"
 
 #include <marlinutil/HelixClass.h>
 
@@ -46,10 +47,6 @@
 #include <iostream>
 #include <climits>
 #include <cfloat>
-
-//CxxUtils/
-#include "fpcompare.h"
-
 
 using namespace lcio ;
 using namespace marlin ;
@@ -125,22 +122,6 @@ TruthTrackFinder::TruthTrackFinder() : Processor("TruthTrackFinder") {
                               bool(false));
   
 	
-}
-
-bool sort_by_radius(EVENT::TrackerHit* hit1, EVENT::TrackerHit* hit2){
-	double radius1 = sqrt((hit1->getPosition()[0])*(hit1->getPosition()[0]) + (hit1->getPosition()[1])*(hit1->getPosition()[1]));
-	double radius2 = sqrt((hit2->getPosition()[0])*(hit2->getPosition()[0]) + (hit2->getPosition()[1])*(hit2->getPosition()[1]));
-  //return (radius1 < radius2);
-  return CxxUtils::fpcompare::less(radius1 , radius2);
-}
-
-bool sort_by_z(EVENT::TrackerHit* hit1, EVENT::TrackerHit* hit2){
-  // sorting by absolute value of Z so the hits are always sorted from close to
-  // the IP outward. This works as long as all hits are either in positive or
-  // negative side
-  const double z1 = fabs(hit1->getPosition()[2]);
-  const double z2 = fabs(hit2->getPosition()[2]);
-  return CxxUtils::fpcompare::less(z1 , z2);
 }
 
 void TruthTrackFinder::init() {

--- a/source/Utils/include/HitsSorterAndDebugger.h
+++ b/source/Utils/include/HitsSorterAndDebugger.h
@@ -1,3 +1,6 @@
+#ifndef HitsSorterAndDebugger_h
+#define HitsSorterAndDebugger_h 1
+
 #include <EVENT/TrackerHit.h>
 #include <EVENT/Track.h>
 #include <IMPL/TrackerHitPlaneImpl.h>
@@ -41,3 +44,4 @@ inline void printHits(const Track* track){
   return;
 }
 
+#endif

--- a/source/Utils/include/HitsSorterAndDebugger.h
+++ b/source/Utils/include/HitsSorterAndDebugger.h
@@ -1,44 +1,45 @@
 #ifndef HitsSorterAndDebugger_h
 #define HitsSorterAndDebugger_h 1
 
-#include <EVENT/TrackerHit.h>
 #include <EVENT/Track.h>
+#include <EVENT/TrackerHit.h>
 #include <IMPL/TrackerHitPlaneImpl.h>
 
 //CxxUtils
 #include "fpcompare.h"
 
-// sorting by value of R(=x^2+y^2) in global coordinated so the hits are always 
+// sorting by value of R(=x^2+y^2) in global coordinated so the hits are always
 // sorted from close to the IP outward
-inline bool sort_by_radius(EVENT::TrackerHit* hit1, EVENT::TrackerHit* hit2){
-  double radius1 = sqrt((hit1->getPosition()[0])*(hit1->getPosition()[0]) + (hit1->getPosition()[1])*(hit1->getPosition()[1]));
-  double radius2 = sqrt((hit2->getPosition()[0])*(hit2->getPosition()[0]) + (hit2->getPosition()[1])*(hit2->getPosition()[1]));
+inline bool sort_by_radius(EVENT::TrackerHit* hit1, EVENT::TrackerHit* hit2) {
+  double radius1 =
+      sqrt((hit1->getPosition()[0]) * (hit1->getPosition()[0]) + (hit1->getPosition()[1]) * (hit1->getPosition()[1]));
+  double radius2 =
+      sqrt((hit2->getPosition()[0]) * (hit2->getPosition()[0]) + (hit2->getPosition()[1]) * (hit2->getPosition()[1]));
   return CxxUtils::fpcompare::less(radius1, radius2);
 }
 
 // sorting by absolute value of Z so the hits are always sorted from close to
 // the IP outward. This works as long as all hits are either in positive or
 // negative side
-inline bool sort_by_z(EVENT::TrackerHit* hit1, EVENT::TrackerHit* hit2){
+inline bool sort_by_z(EVENT::TrackerHit* hit1, EVENT::TrackerHit* hit2) {
   const double z1 = fabs(hit1->getPosition()[2]);
   const double z2 = fabs(hit2->getPosition()[2]);
-  return CxxUtils::fpcompare::less(z1 , z2);
+  return CxxUtils::fpcompare::less(z1, z2);
 }
 
-inline void printHits(const TrackerHitVec& hitVector){
+inline void printHits(const TrackerHitVec& hitVector) {
   int nHits = hitVector.size();
-  for(int itHit=0;itHit<nHits;itHit++){
+  for (int itHit = 0; itHit < nHits; itHit++) {
     // Get the tracker hit and print global coordinates of the hit
     TrackerHitPlane* hit = static_cast<TrackerHitPlane*>(hitVector.at(itHit));
-    streamlog_out( DEBUG5 ) << " Hit #" << itHit 
-                            << ", (x,y,z) = (" << hit->getPosition()[0] << "," << hit->getPosition()[1] 
-                            << "," << hit->getPosition()[2] << ")" << std::endl;
+    streamlog_out(DEBUG5) << " Hit #" << itHit << ", (x,y,z) = (" << hit->getPosition()[0] << "," << hit->getPosition()[1]
+                          << "," << hit->getPosition()[2] << ")" << std::endl;
   }
   return;
 }
 
 // Print out the hits belonging to the track
-inline void printHits(const Track* track){
+inline void printHits(const Track* track) {
   const TrackerHitVec& hitVector = track->getTrackerHits();
   printHits(hitVector);
   return;

--- a/source/Utils/include/HitsSorterAndDebugger.h
+++ b/source/Utils/include/HitsSorterAndDebugger.h
@@ -1,0 +1,43 @@
+#include <EVENT/TrackerHit.h>
+#include <EVENT/Track.h>
+#include <IMPL/TrackerHitPlaneImpl.h>
+
+//CxxUtils
+#include "fpcompare.h"
+
+// sorting by value of R(=x^2+y^2) in global coordinated so the hits are always 
+// sorted from close to the IP outward
+inline bool sort_by_radius(EVENT::TrackerHit* hit1, EVENT::TrackerHit* hit2){
+  double radius1 = sqrt((hit1->getPosition()[0])*(hit1->getPosition()[0]) + (hit1->getPosition()[1])*(hit1->getPosition()[1]));
+  double radius2 = sqrt((hit2->getPosition()[0])*(hit2->getPosition()[0]) + (hit2->getPosition()[1])*(hit2->getPosition()[1]));
+  return CxxUtils::fpcompare::less(radius1, radius2);
+}
+
+// sorting by absolute value of Z so the hits are always sorted from close to
+// the IP outward. This works as long as all hits are either in positive or
+// negative side
+inline bool sort_by_z(EVENT::TrackerHit* hit1, EVENT::TrackerHit* hit2){
+  const double z1 = fabs(hit1->getPosition()[2]);
+  const double z2 = fabs(hit2->getPosition()[2]);
+  return CxxUtils::fpcompare::less(z1 , z2);
+}
+
+inline void printHits(const TrackerHitVec& hitVector){
+  int nHits = hitVector.size();
+  for(int itHit=0;itHit<nHits;itHit++){
+    // Get the tracker hit and print global coordinates of the hit
+    TrackerHitPlane* hit = static_cast<TrackerHitPlane*>(hitVector.at(itHit));
+    streamlog_out( DEBUG5 ) << " Hit #" << itHit 
+                            << ", (x,y,z) = (" << hit->getPosition()[0] << "," << hit->getPosition()[1] 
+                            << "," << hit->getPosition()[2] << ")" << std::endl;
+  }
+  return;
+}
+
+// Print out the hits belonging to the track
+inline void printHits(const Track* track){
+  const TrackerHitVec& hitVector = track->getTrackerHits();
+  printHits(hitVector);
+  return;
+}
+


### PR DESCRIPTION
BEGINRELEASENOTES
- ClonesAndSplitTracksFinder 
  - If mergeSplitTracks set to `true`, pairs of tracks above a minimum pT requirements are compared in terms of pt, theta and phi
  - For each pair of reconstructed tracks: calculate significance for each parameter, impose a cut on the significance for each parameter, remove possible common hits and sort them in r, fit the new merged track
  - Results show positive effect on both single muons and complex events, with no significant increase of the run time ([Link to the slides](https://indico.cern.ch/event/920887/))

ENDRELEASENOTES