### PR TITLE
Add option for time smearing and TOF compensation in DDPlanarDigiProcessor

### DIFF
--- a/source/Digitisers/include/DDPlanarDigiProcessor.h
+++ b/source/Digitisers/include/DDPlanarDigiProcessor.h
@@ -100,6 +100,7 @@ protected:
   
   FloatVec _resU ;
   FloatVec _resV ;
+  FloatVec _resT ;
   
   bool _isStrip;
   

--- a/source/Digitisers/include/DDPlanarDigiProcessor.h
+++ b/source/Digitisers/include/DDPlanarDigiProcessor.h
@@ -111,6 +111,11 @@ protected:
   bool _forceHitsOntoSurface  ;
   double _minEnergy ;
 
+  bool _useTimeWindow ;
+  bool _correctTimesForPropagation ;
+  FloatVec _timeWindow_min ;
+  FloatVec _timeWindow_max ;
+
   std::vector<TH1F*> _h ;
   
 } ;

--- a/source/Digitisers/src/DDPlanarDigiProcessor.cc
+++ b/source/Digitisers/src/DDPlanarDigiProcessor.cc
@@ -368,11 +368,11 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
       // Calculating the propagation time in ns
       float dt(0.0);
       if (_correctTimesForPropagation) {
-        dt = ( dd4hep::mm * oldPos.r() ) / ( TMath::C() / 1e6 );
+        dt = oldPos.r() / ( TMath::C() / 1e6 );
       }
       
-      if (_useTimeWindow && ( hitT+dt < timeWindow_min || hitT+dt > timeWindow_max) ) {
-        streamlog_out(DEBUG4) << "hit at T: " << simTHit->getTime()+dt << " smeared to: " << hitT+dt << " is outside the time window: hit dropped"  << std::endl;
+      if (_useTimeWindow && ( hitT-dt < timeWindow_min || hitT-dt > timeWindow_max) ) {
+        streamlog_out(DEBUG4) << "hit at T: " << simTHit->getTime()-dt << " smeared to: " << hitT-dt << " is outside the time window: hit dropped"  << std::endl;
         ++nDismissedHits;
         continue; 
       }

--- a/source/Digitisers/src/DDPlanarDigiProcessor.cc
+++ b/source/Digitisers/src/DDPlanarDigiProcessor.cc
@@ -357,13 +357,13 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
       
       // Smearing time of the hit
       if (_resT.size() and _resT[0] > 0.0) {
-      float resT = _resT.size() > 1 ? _resT.at(layer) : _resT.at(0); 
-      double tSmear  = resT > 0.0 ? gsl_ran_gaussian( _rng, resT ) : 0.0;
-      _h[hT]->Fill( resT > 0.0 ? tSmear / resT : 0.0 );
-      _h[diffT]->Fill( tSmear );
+        float resT = _resT.size() > 1 ? _resT.at(layer) : _resT.at(0);
+        double tSmear  = resT > 0.0 ? gsl_ran_gaussian( _rng, resT ) : 0.0;
+        _h[hT]->Fill( resT > 0.0 ? tSmear / resT : 0.0 );
+        _h[diffT]->Fill( tSmear );
 
-      hitT += tSmear;
-      streamlog_out(DEBUG3) << "smeared hit at T: " << simTHit->getTime() << " ns to T: " << hitT << " ns according to resolution: " << resT << " ns" << std::endl;
+        hitT += tSmear;
+        streamlog_out(DEBUG3) << "smeared hit at T: " << simTHit->getTime() << " ns to T: " << hitT << " ns according to resolution: " << resT << " ns" << std::endl;
       }
      
       // Correcting for the propagation time
@@ -378,10 +378,10 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
         float timeWindow_min = _timeWindow_min.size() > 1 ? _timeWindow_min.at(layer) : _timeWindow_min.at(0);
         float timeWindow_max = _timeWindow_max.size() > 1 ? _timeWindow_max.at(layer) : _timeWindow_max.at(0);
         if ( hitT < timeWindow_min || hitT > timeWindow_max ) {
-        streamlog_out(DEBUG4) << "hit at T: " << simTHit->getTime() << " smeared to: " << hitT << " is outside the time window: hit dropped"  << std::endl;
-        ++nDismissedHits;
+          streamlog_out(DEBUG4) << "hit at T: " << simTHit->getTime() << " smeared to: " << hitT << " is outside the time window: hit dropped"  << std::endl;
+          ++nDismissedHits;
+          continue;
         }
-        continue; 
       }
 
 

--- a/source/Digitisers/src/DDPlanarDigiProcessor.cc
+++ b/source/Digitisers/src/DDPlanarDigiProcessor.cc
@@ -365,10 +365,7 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
       hitT += tSmear;
       streamlog_out(DEBUG3) << "smeared hit at T: " << simTHit->getTime() << " ns to T: " << hitT << " ns according to resolution: " << resT << " ns" << std::endl;
       }
-      
-      float timeWindow_min = _timeWindow_min.size() > 1 ? _timeWindow_min.at(layer) : _timeWindow_min.at(0);
-      float timeWindow_max = _timeWindow_max.size() > 1 ? _timeWindow_max.at(layer) : _timeWindow_max.at(0);
-
+     
       // Correcting for the propagation time
       if (_correctTimesForPropagation) {
         double dt = oldPos.r() / ( TMath::C() / 1e6 );
@@ -376,9 +373,14 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
         streamlog_out(DEBUG3) << "corrected hit at R: " << oldPos.r() << " mm by propagation time: " << dt << " ns to T: " << hitT << " ns" << std::endl;
       }
       
-      if (_useTimeWindow && ( hitT < timeWindow_min || hitT > timeWindow_max) ) {
-        streamlog_out(DEBUG4) << "hit at T: " << hitT << " smeared to: " << hitT << " is outside the time window: hit dropped"  << std::endl;
+      // Skipping the hit if its time is outside the acceptance time window
+      if (_useTimeWindow) {
+        float timeWindow_min = _timeWindow_min.size() > 1 ? _timeWindow_min.at(layer) : _timeWindow_min.at(0);
+        float timeWindow_max = _timeWindow_max.size() > 1 ? _timeWindow_max.at(layer) : _timeWindow_max.at(0);
+        if ( hitT < timeWindow_min || hitT > timeWindow_max ) {
+        streamlog_out(DEBUG4) << "hit at T: " << simTHit->getTime() << " smeared to: " << hitT << " is outside the time window: hit dropped"  << std::endl;
         ++nDismissedHits;
+        }
         continue; 
       }
 

--- a/source/Digitisers/src/DDPlanarDigiProcessor.cc
+++ b/source/Digitisers/src/DDPlanarDigiProcessor.cc
@@ -190,7 +190,7 @@ void DDPlanarDigiProcessor::init() {
 
   _h[ diffu ] = new TH1F( "diffu" , "diff u" , 1000, -5. , +5. );
   _h[ diffv ] = new TH1F( "diffv" , "diff v" , 1000, -5. , +5. );
-  _h[ diffT ] = new TH1F( "diffT" , "diff time" , 1000, -500. , +500. );
+  _h[ diffT ] = new TH1F( "diffT" , "diff time" , 1000, -5. , +5. );
 
   _h[ hitE ] = new TH1F( "hitE" , "hitEnergy in keV" , 1000, 0 , 200 );
   

--- a/source/Digitisers/src/DDPlanarDigiProcessor.cc
+++ b/source/Digitisers/src/DDPlanarDigiProcessor.cc
@@ -45,8 +45,8 @@ DDPlanarDigiProcessor aDDPlanarDigiProcessor ;
 DDPlanarDigiProcessor::DDPlanarDigiProcessor() : Processor("DDPlanarDigiProcessor") {
   
   // modify processor description
-  _description = "DDPlanarDigiProcessor creates TrackerHits from SimTrackerHits, smearing them according to the input parameters."
-    "The geoemtry of the surface is taken from the DDRec::Surface asscociated to the hit via the cellID" ;
+  _description = "DDPlanarDigiProcessor creates TrackerHits from SimTrackerHits, smearing their position and time according to the input parameters."
+    "The geoemtry of the surface is taken from the DDRec::Surface associated to the hit via the cellID" ;
   
   
   // register steering parameters: name, description, class-variable, default value
@@ -64,8 +64,16 @@ DDPlanarDigiProcessor::DDPlanarDigiProcessor() : Processor("DDPlanarDigiProcesso
 
   registerProcessorParameter( "ResolutionV" , 
                               "resolution in direction of v - either one per layer or one for all layers " ,
-                             _resV ,
+                              _resV ,
                               resVEx );
+
+  FloatVec resTEx ;
+  resTEx.push_back( 0.0 ) ;
+
+  registerProcessorParameter( "ResolutionT" , 
+                              "resolution of time - either one per layer or one for all layers " ,
+                              _resT ,
+                              resTEx );
 
   registerProcessorParameter( "IsStrip",
                               "whether hits are 1D strip hits",
@@ -118,9 +126,11 @@ DDPlanarDigiProcessor::DDPlanarDigiProcessor() : Processor("DDPlanarDigiProcesso
 enum {
   hu = 0,
   hv,
+  hT,
   hitE,
   diffu,
   diffv,
+  diffT,
   hSize 
 } ;
 
@@ -176,9 +186,11 @@ void DDPlanarDigiProcessor::init() {
 
   _h[ hu ] = new TH1F( "hu" , "smearing u" , 50, -5. , +5. );
   _h[ hv ] = new TH1F( "hv" , "smearing v" , 50, -5. , +5. );
+  _h[ hT ] = new TH1F( "hT" , "smearing time" , 50, -5. , +5. );
 
   _h[ diffu ] = new TH1F( "diffu" , "diff u" , 1000, -5. , +5. );
   _h[ diffv ] = new TH1F( "diffv" , "diff v" , 1000, -5. , +5. );
+  _h[ diffT ] = new TH1F( "diffT" , "diff time" , 1000, -500. , +500. );
 
   _h[ hitE ] = new TH1F( "hitE" , "hitEnergy in keV" , 1000, 0 , 200 );
   
@@ -235,10 +247,10 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
 
       SimTrackerHit* simTHit = dynamic_cast<SimTrackerHit*>( STHcol->getElementAt( i ) ) ;
 
-      _h[hitE]->Fill( simTHit->getEDep() * 1e6 );
+      _h[hitE]->Fill( simTHit->getEDep() * (dd4hep::GeV / dd4hep::keV) );
 
       if( simTHit->getEDep() < _minEnergy ) {
-        streamlog_out( DEBUG ) << "Hit with insufficient energy " << simTHit->getEDep()*1e6 << " keV" << std::endl;
+        streamlog_out( DEBUG ) << "Hit with insufficient energy " << simTHit->getEDep() * (dd4hep::GeV / dd4hep::keV) << " keV" << std::endl;
         continue;
       }
       
@@ -329,6 +341,7 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
       
       float resU = ( _resU.size() > 1 ?   _resU.at(  layer )     : _resU.at(0)   )  ;
       float resV = ( _resV.size() > 1 ?   _resV.at(  layer )     : _resV.at(0)   )  ; 
+      float resT = ( _resT.size() > 1 ?   _resT.at(  layer )     : _resT.at(0)   )  ; 
 
 
       while( tries < MaxTries ) {
@@ -380,14 +393,18 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
         }
         
         ++tries;
-       }
-      
+      }
       
       if( accept_hit == false ) {
         streamlog_out(DEBUG4) << "hit could not be smeared within ladder after " << MaxTries << "  tries: hit dropped"  << std::endl;
         ++nDismissedHits;
         continue; 
       } 
+
+      // Smearing time of the hit
+      double tSmear  = resT == 0.0 ? 0.0 : gsl_ran_gaussian( _rng, resT ) ;
+      _h[hT]->Fill( resT == 0.0 ? 0.0 : tSmear / resT );
+      _h[diffT]->Fill( tSmear );
       
       //**************************************************************************
       // Store hit variables to TrackerHitPlaneImpl
@@ -401,7 +418,7 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
       trkHit->setCellID1( cellID1 ) ;
       
       trkHit->setPosition( newPos.const_array()  ) ;
-      trkHit->setTime( simTHit->getTime() ) ;
+      trkHit->setTime( simTHit->getTime() + tSmear ) ;
       trkHit->setEDep( simTHit->getEDep() ) ;
 
       float u_direction[2] ;

--- a/source/Digitisers/src/DDPlanarDigiProcessor.cc
+++ b/source/Digitisers/src/DDPlanarDigiProcessor.cc
@@ -73,7 +73,7 @@ DDPlanarDigiProcessor::DDPlanarDigiProcessor() : Processor("DDPlanarDigiProcesso
   resTEx.push_back( -1 ) ;
 
   registerProcessorParameter( "ResolutionT" , 
-                              "resolution of time - either one per layer or one for all layers " ,
+                              "resolution of time - either one per layer or one for all layers. if the single entry is negative, disable time smearing. " ,
                               _resT ,
                               resTEx );
 
@@ -353,15 +353,18 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
       // Smear time of the hit and apply the time window cut if needed
       //***************************************************************
       
+      double hitT = simTHit->getTime();
+      
       // Smearing time of the hit
+      if (_resT.size() and _resT[0] > 0.0) {
       float resT = _resT.size() > 1 ? _resT.at(layer) : _resT.at(0); 
-      double tSmear  = resT == 0.0 ? 0.0 : gsl_ran_gaussian( _rng, resT );
-      _h[hT]->Fill( resT == 0.0 ? 0.0 : tSmear / resT );
+      double tSmear  = resT > 0.0 ? gsl_ran_gaussian( _rng, resT ) : 0.0;
+      _h[hT]->Fill( resT > 0.0 ? tSmear / resT : 0.0 );
       _h[diffT]->Fill( tSmear );
 
-      // Skipping the hit if its time is outside the acceptance time window
-      double hitT = simTHit->getTime() + tSmear;
+      hitT += tSmear;
       streamlog_out(DEBUG3) << "smeared hit at T: " << simTHit->getTime() << " ns to T: " << hitT << " ns according to resolution: " << resT << " ns" << std::endl;
+      }
       
       float timeWindow_min = _timeWindow_min.size() > 1 ? _timeWindow_min.at(layer) : _timeWindow_min.at(0);
       float timeWindow_max = _timeWindow_max.size() > 1 ? _timeWindow_max.at(layer) : _timeWindow_max.at(0);

--- a/source/Digitisers/src/DDPlanarDigiProcessor.cc
+++ b/source/Digitisers/src/DDPlanarDigiProcessor.cc
@@ -70,7 +70,7 @@ DDPlanarDigiProcessor::DDPlanarDigiProcessor() : Processor("DDPlanarDigiProcesso
                               resVEx );
 
   FloatVec resTEx ;
-  resTEx.push_back( 0.0 ) ;
+  resTEx.push_back( -1 ) ;
 
   registerProcessorParameter( "ResolutionT" , 
                               "resolution of time - either one per layer or one for all layers " ,


### PR DESCRIPTION

BEGINRELEASENOTES
- Added time smearing to the DDPlanarDigiProcessor 
- Introduced a time window for digitized hits in the DDPlanarDigiProcessor 
- Introduced TOF compensation for digitized hits in the DDPlanarDigiProcessor 

ENDRELEASENOTES