### PR TITLE
 Add option for time smearing and TOF compensation in DDPlanarDigiProcessor

### DIFF
--- a/source/Digitisers/include/DDPlanarDigiProcessor.h
+++ b/source/Digitisers/include/DDPlanarDigiProcessor.h
@@ -100,6 +100,7 @@ protected:
   
   FloatVec _resU ;
   FloatVec _resV ;
+  FloatVec _resT ;
   
   bool _isStrip;
   

--- a/source/Digitisers/include/DDPlanarDigiProcessor.h
+++ b/source/Digitisers/include/DDPlanarDigiProcessor.h
@@ -111,6 +111,11 @@ protected:
   bool _forceHitsOntoSurface  ;
   double _minEnergy ;
 
+  bool _useTimeWindow ;
+  bool _correctTimesForPropagation ;
+  FloatVec _timeWindow_min ;
+  FloatVec _timeWindow_max ;
+
   std::vector<TH1F*> _h ;
   
 } ;

--- a/source/Digitisers/src/DDPlanarDigiProcessor.cc
+++ b/source/Digitisers/src/DDPlanarDigiProcessor.cc
@@ -191,7 +191,7 @@ void DDPlanarDigiProcessor::init() {
 
   _h[ diffu ] = new TH1F( "diffu" , "diff u" , 1000, -5. , +5. );
   _h[ diffv ] = new TH1F( "diffv" , "diff v" , 1000, -5. , +5. );
-  _h[ diffT ] = new TH1F( "diffT" , "diff time" , 1000, -500. , +500. );
+  _h[ diffT ] = new TH1F( "diffT" , "diff time" , 1000, -5. , +5. );
 
   _h[ hitE ] = new TH1F( "hitE" , "hitEnergy in keV" , 1000, 0 , 200 );
   

--- a/source/Digitisers/src/DDPlanarDigiProcessor.cc
+++ b/source/Digitisers/src/DDPlanarDigiProcessor.cc
@@ -71,7 +71,7 @@ DDPlanarDigiProcessor::DDPlanarDigiProcessor() : Processor("DDPlanarDigiProcesso
                               resVEx );
 
   FloatVec resTEx ;
-  resTEx.push_back( 0.0 ) ;
+  resTEx.push_back( -1 ) ;
 
   registerProcessorParameter( "ResolutionT" , 
                               "resolution of time - either one per layer or one for all layers " ,

--- a/source/Digitisers/src/DDPlanarDigiProcessor.cc
+++ b/source/Digitisers/src/DDPlanarDigiProcessor.cc
@@ -367,11 +367,11 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
       // Calculating the propagation time in ns
       float dt(0.0);
       if (_correctTimesForPropagation) {
-        dt = ( dd4hep::mm * oldPos.r() ) / ( TMath::C() / 1e6 );
+        dt = oldPos.r() / ( TMath::C() / 1e6 );
       }
       
-      if (_useTimeWindow && ( hitT+dt < timeWindow_min || hitT+dt > timeWindow_max) ) {
-        streamlog_out(DEBUG4) << "hit at T: " << simTHit->getTime()+dt << " smeared to: " << hitT+dt << " is outside the time window: hit dropped"  << std::endl;
+      if (_useTimeWindow && ( hitT-dt < timeWindow_min || hitT-dt > timeWindow_max) ) {
+        streamlog_out(DEBUG4) << "hit at T: " << simTHit->getTime()-dt << " smeared to: " << hitT-dt << " is outside the time window: hit dropped"  << std::endl;
         ++nDismissedHits;
         continue; 
       }

--- a/source/Digitisers/src/DDPlanarDigiProcessor.cc
+++ b/source/Digitisers/src/DDPlanarDigiProcessor.cc
@@ -364,10 +364,7 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
       hitT += tSmear;
       streamlog_out(DEBUG3) << "smeared hit at T: " << simTHit->getTime() << " ns to T: " << hitT << " ns according to resolution: " << resT << " ns" << std::endl;
       }
-      
-      float timeWindow_min = _timeWindow_min.size() > 1 ? _timeWindow_min.at(layer) : _timeWindow_min.at(0);
-      float timeWindow_max = _timeWindow_max.size() > 1 ? _timeWindow_max.at(layer) : _timeWindow_max.at(0);
-
+     
       // Correcting for the propagation time
       if (_correctTimesForPropagation) {
         double dt = oldPos.r() / ( TMath::C() / 1e6 );
@@ -375,9 +372,14 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
         streamlog_out(DEBUG3) << "corrected hit at R: " << oldPos.r() << " mm by propagation time: " << dt << " ns to T: " << hitT << " ns" << std::endl;
       }
       
-      if (_useTimeWindow && ( hitT < timeWindow_min || hitT > timeWindow_max) ) {
-        streamlog_out(DEBUG4) << "hit at T: " << hitT << " smeared to: " << hitT << " is outside the time window: hit dropped"  << std::endl;
+      // Skipping the hit if its time is outside the acceptance time window
+      if (_useTimeWindow) {
+        float timeWindow_min = _timeWindow_min.size() > 1 ? _timeWindow_min.at(layer) : _timeWindow_min.at(0);
+        float timeWindow_max = _timeWindow_max.size() > 1 ? _timeWindow_max.at(layer) : _timeWindow_max.at(0);
+        if ( hitT < timeWindow_min || hitT > timeWindow_max ) {
+        streamlog_out(DEBUG4) << "hit at T: " << simTHit->getTime() << " smeared to: " << hitT << " is outside the time window: hit dropped"  << std::endl;
         ++nDismissedHits;
+        }
         continue; 
       }
 

--- a/source/Digitisers/src/DDPlanarDigiProcessor.cc
+++ b/source/Digitisers/src/DDPlanarDigiProcessor.cc
@@ -120,14 +120,14 @@ DDPlanarDigiProcessor::DDPlanarDigiProcessor() : Processor("DDPlanarDigiProcesso
                               _minEnergy,
                               double(0.0) );
 
+  registerProcessorParameter( "CorrectTimesForPropagation" , 
+                              "Correct hit time for the propagation: radial distance/c (default: false)" ,
+                              _correctTimesForPropagation ,
+                              bool(false) );
+
   registerProcessorParameter( "UseTimeWindow" , 
                               "Only accept hits with time (after smearing) within the specified time window (default: false)" ,
                               _useTimeWindow ,
-                              bool(false) );
-
-  registerProcessorParameter( "CorrectTimesForPropagation" , 
-                              "In the time window correct hit time for the propagation: radial distance/c (default: false)" ,
-                              _correctTimesForPropagation ,
                               bool(false) );
 
 FloatVec timeWindow_min;
@@ -360,18 +360,20 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
 
       // Skipping the hit if its time is outside the acceptance time window
       double hitT = simTHit->getTime() + tSmear;
+      streamlog_out(DEBUG3) << "smeared hit at T: " << simTHit->getTime() << " ns to T: " << hitT << " ns according to resolution: " << resT << " ns" << std::endl;
       
       float timeWindow_min = _timeWindow_min.size() > 1 ? _timeWindow_min.at(layer) : _timeWindow_min.at(0);
       float timeWindow_max = _timeWindow_max.size() > 1 ? _timeWindow_max.at(layer) : _timeWindow_max.at(0);
 
-      // Calculating the propagation time in ns
-      float dt(0.0);
+      // Correcting for the propagation time
       if (_correctTimesForPropagation) {
-        dt = oldPos.r() / ( TMath::C() / 1e6 );
+        double dt = oldPos.r() / ( TMath::C() / 1e6 );
+        hitT -= dt;
+        streamlog_out(DEBUG3) << "corrected hit at R: " << oldPos.r() << " mm by propagation time: " << dt << " ns to T: " << hitT << " ns" << std::endl;
       }
       
-      if (_useTimeWindow && ( hitT-dt < timeWindow_min || hitT-dt > timeWindow_max) ) {
-        streamlog_out(DEBUG4) << "hit at T: " << simTHit->getTime()-dt << " smeared to: " << hitT-dt << " is outside the time window: hit dropped"  << std::endl;
+      if (_useTimeWindow && ( hitT < timeWindow_min || hitT > timeWindow_max) ) {
+        streamlog_out(DEBUG4) << "hit at T: " << hitT << " smeared to: " << hitT << " is outside the time window: hit dropped"  << std::endl;
         ++nDismissedHits;
         continue; 
       }
@@ -534,7 +536,7 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
     evt->addCollection( trkhitVec , _outColName ) ;
     evt->addCollection( thsthcol , _outRelColName ) ;
     
-    streamlog_out(DEBUG4) << "Created " << nCreatedHits << " hits, " << nDismissedHits << " hits  dismissed as not on sensitive element\n";
+    streamlog_out(DEBUG4) << "Created " << nCreatedHits << " hits, " << nDismissedHits << " hits  dismissed\n";
     
   }
   _nEvt ++ ;

--- a/source/Digitisers/src/DDPlanarDigiProcessor.cc
+++ b/source/Digitisers/src/DDPlanarDigiProcessor.cc
@@ -356,13 +356,13 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
       
       // Smearing time of the hit
       if (_resT.size() and _resT[0] > 0.0) {
-      float resT = _resT.size() > 1 ? _resT.at(layer) : _resT.at(0); 
-      double tSmear  = resT > 0.0 ? gsl_ran_gaussian( _rng, resT ) : 0.0;
-      _h[hT]->Fill( resT > 0.0 ? tSmear / resT : 0.0 );
-      _h[diffT]->Fill( tSmear );
+        float resT = _resT.size() > 1 ? _resT.at(layer) : _resT.at(0);
+        double tSmear  = resT > 0.0 ? gsl_ran_gaussian( _rng, resT ) : 0.0;
+        _h[hT]->Fill( resT > 0.0 ? tSmear / resT : 0.0 );
+        _h[diffT]->Fill( tSmear );
 
-      hitT += tSmear;
-      streamlog_out(DEBUG3) << "smeared hit at T: " << simTHit->getTime() << " ns to T: " << hitT << " ns according to resolution: " << resT << " ns" << std::endl;
+        hitT += tSmear;
+        streamlog_out(DEBUG3) << "smeared hit at T: " << simTHit->getTime() << " ns to T: " << hitT << " ns according to resolution: " << resT << " ns" << std::endl;
       }
      
       // Correcting for the propagation time
@@ -377,10 +377,10 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
         float timeWindow_min = _timeWindow_min.size() > 1 ? _timeWindow_min.at(layer) : _timeWindow_min.at(0);
         float timeWindow_max = _timeWindow_max.size() > 1 ? _timeWindow_max.at(layer) : _timeWindow_max.at(0);
         if ( hitT < timeWindow_min || hitT > timeWindow_max ) {
-        streamlog_out(DEBUG4) << "hit at T: " << simTHit->getTime() << " smeared to: " << hitT << " is outside the time window: hit dropped"  << std::endl;
-        ++nDismissedHits;
+          streamlog_out(DEBUG4) << "hit at T: " << simTHit->getTime() << " smeared to: " << hitT << " is outside the time window: hit dropped"  << std::endl;
+          ++nDismissedHits;
+          continue;
         }
-        continue; 
       }
 
 

--- a/source/Digitisers/src/DDPlanarDigiProcessor.cc
+++ b/source/Digitisers/src/DDPlanarDigiProcessor.cc
@@ -18,6 +18,8 @@
 #include "DD4hep/Detector.h"
 #include "DD4hep/DD4hepUnits.h"
 
+#include <TMath.h>
+
 #include <gsl/gsl_rng.h>
 #include <gsl/gsl_randist.h>
 
@@ -118,6 +120,30 @@ DDPlanarDigiProcessor::DDPlanarDigiProcessor() : Processor("DDPlanarDigiProcesso
                               _minEnergy,
                               double(0.0) );
 
+  registerProcessorParameter( "UseTimeWindow" , 
+                              "Only accept hits with time (after smearing) within the specified time window (default: false)" ,
+                              _useTimeWindow ,
+                              bool(false) );
+
+  registerProcessorParameter( "CorrectTimesForPropagation" , 
+                              "In the time window correct hit time for the propagation: radial distance/c (default: false)" ,
+                              _correctTimesForPropagation ,
+                              bool(false) );
+
+FloatVec timeWindow_min;
+  timeWindow_min.push_back( -1e9 );
+  registerProcessorParameter( "TimeWindowMin" ,
+                              "Minimum time a hit must have after smearing to be accepted [ns] - either one per layer or one for all layers",
+                              _timeWindow_min,
+                              timeWindow_min );
+
+FloatVec timeWindow_max;
+  timeWindow_max.push_back( 1e9 );
+  registerProcessorParameter( "TimeWindowMax" ,
+                              "Maximum time a hit must have after smearing to be accepted [ns] - either one per layer or one for all layers",
+                              _timeWindow_max,
+                              timeWindow_max );
+
   
   // setup the list of supported detectors
   
@@ -129,6 +155,7 @@ enum {
   hv,
   hT,
   hitE,
+  hitsAccepted,
   diffu,
   diffv,
   diffT,
@@ -194,6 +221,7 @@ void DDPlanarDigiProcessor::init() {
   _h[ diffT ] = new TH1F( "diffT" , "diff time" , 1000, -5. , +5. );
 
   _h[ hitE ] = new TH1F( "hitE" , "hitEnergy in keV" , 1000, 0 , 200 );
+  _h[ hitsAccepted ] = new TH1F( "hitsAccepted" , "Fraction of accepted hits [%]" , 201, 0 , 100.5 );
   
 }
 
@@ -286,7 +314,7 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
       dd4hep::rec::Vector3D newPos ;
 
      //************************************************************
-      // Check if Hit is inside senstive 
+      // Check if Hit is inside sensitive 
       //************************************************************
       
       if ( ! surf->insideBounds( dd4hep::mm * oldPos ) ) {
@@ -319,10 +347,39 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
           continue; 
         }
       }
+
+      //***************************************************************
+      // Smear time of the hit and apply the time window cut if needed
+      //***************************************************************
       
-      //**************************************************************************
-      // Try to smear the hit but ensure the hit is inside the sensitive region
-      //**************************************************************************
+      // Smearing time of the hit
+      float resT = _resT.size() > 1 ? _resT.at(layer) : _resT.at(0); 
+      double tSmear  = resT == 0.0 ? 0.0 : gsl_ran_gaussian( _rng, resT );
+      _h[hT]->Fill( resT == 0.0 ? 0.0 : tSmear / resT );
+      _h[diffT]->Fill( tSmear );
+
+      // Skipping the hit if its time is outside the acceptance time window
+      double hitT = simTHit->getTime() + tSmear;
+      
+      float timeWindow_min = _timeWindow_min.size() > 1 ? _timeWindow_min.at(layer) : _timeWindow_min.at(0);
+      float timeWindow_max = _timeWindow_max.size() > 1 ? _timeWindow_max.at(layer) : _timeWindow_max.at(0);
+
+      // Calculating the propagation time in ns
+      float dt(0.0);
+      if (_correctTimesForPropagation) {
+        dt = ( dd4hep::mm * oldPos.r() ) / ( TMath::C() / 1e6 );
+      }
+      
+      if (_useTimeWindow && ( hitT+dt < timeWindow_min || hitT+dt > timeWindow_max) ) {
+        streamlog_out(DEBUG4) << "hit at T: " << simTHit->getTime()+dt << " smeared to: " << hitT+dt << " is outside the time window: hit dropped"  << std::endl;
+        ++nDismissedHits;
+        continue; 
+      }
+
+
+      //*********************************************************************************
+      // Try to smear the hit position but ensure the hit is inside the sensitive region
+      //*********************************************************************************
       
       dd4hep::rec::Vector3D u = surf->u() ;
       dd4hep::rec::Vector3D v = surf->v() ;
@@ -333,14 +390,12 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
       double uL = lv[0] / dd4hep::mm ;
       double vL = lv[1] / dd4hep::mm ;
 
-
       bool accept_hit = false ;
       unsigned  tries   =  0 ;              
       static const unsigned MaxTries = 10 ; 
       
       float resU = ( _resU.size() > 1 ?   _resU.at(  layer )     : _resU.at(0)   )  ;
       float resV = ( _resV.size() > 1 ?   _resV.at(  layer )     : _resV.at(0)   )  ; 
-      float resT = ( _resT.size() > 1 ?   _resT.at(  layer )     : _resT.at(0)   )  ; 
 
 
       while( tries < MaxTries ) {
@@ -399,11 +454,6 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
         ++nDismissedHits;
         continue; 
       } 
-
-      // Smearing time of the hit
-      double tSmear  = resT == 0.0 ? 0.0 : gsl_ran_gaussian( _rng, resT ) ;
-      _h[hT]->Fill( resT == 0.0 ? 0.0 : tSmear / resT );
-      _h[diffT]->Fill( tSmear );
       
       //**************************************************************************
       // Store hit variables to TrackerHitPlaneImpl
@@ -417,7 +467,7 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
       trkHit->setCellID1( cellID1 ) ;
       
       trkHit->setPosition( newPos.const_array()  ) ;
-      trkHit->setTime( simTHit->getTime() + tSmear ) ;
+      trkHit->setTime( hitT ) ;
       trkHit->setEDep( simTHit->getEDep() ) ;
 
       float u_direction[2] ;
@@ -472,6 +522,10 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
 
     // Create relation collection
     thsthcol = thitNav.createLCCollection();
+    
+    // Filling the fraction of accepted hits in the event
+    float accFraction = nSimHits > 0 ? float(nCreatedHits) / float(nSimHits) * 100.0 : 0.0;
+    _h[hitsAccepted]->Fill( accFraction );
     
     //**************************************************************************
     // Add collection to event


### PR DESCRIPTION
Rebased branch of https://github.com/iLCSoft/MarlinTrkProcessors/pull/48 to fix conflicts

BEGINRELEASENOTES
- Added time smearing to the DDPlanarDigiProcessor 
- Introduced a time window for digitized hits in the DDPlanarDigiProcessor 
- Introduced TOF compensation for digitized hits in the DDPlanarDigiProcessor 

ENDRELEASENOTES