### PR TITLE
Fix position of the digitized SET strip hits in the SET

### DIFF
--- a/source/Digitisers/src/DDPlanarDigiProcessor.cc
+++ b/source/Digitisers/src/DDPlanarDigiProcessor.cc
@@ -342,25 +342,24 @@ void DDPlanarDigiProcessor::processEvent( LCEvent * evt ) {
         // dd4hep::rec::Vector3D newPosTmp = oldPos +  uSmear * u ;  
         // if( ! _isStrip )  newPosTmp = newPosTmp +  vSmear * v ;  
         
-        double xStripPos, yStripPos, zStripPos;
-        if ( _subDetName == "SET" && _isStrip){
-            //Find intersection of the strip with the z=centerOfSensor plane to set it as the center of the SET strip
-            dd4hep::rec::Vector3D simHitPosSmeared = (1./dd4hep::mm) * ( surf->localToGlobal( dd4hep::rec::Vector2D( (uL+uSmear)*dd4hep::mm, 0.) ) );
-            zStripPos = surf->origin()[2] / dd4hep::mm ;
-            double lineParam = (zStripPos - simHitPosSmeared[2])/v[2];
-            xStripPos = simHitPosSmeared[0] + lineParam*v[0];
-            yStripPos = simHitPosSmeared[1] + lineParam*v[1];
-        }
-
         dd4hep::rec::Vector3D newPosTmp;
-        if (! _isStrip){
-            newPosTmp = (1./dd4hep::mm) * ( surf->localToGlobal( dd4hep::rec::Vector2D( (uL+uSmear)*dd4hep::mm, (vL+vSmear)*dd4hep::mm ) ) );
-        }
-        else if (_subDetName == "SET"){
-            newPosTmp = dd4hep::rec::Vector3D(xStripPos, yStripPos, zStripPos);
+        if (_isStrip){
+            if (_subDetName == "SET"){
+                double xStripPos, yStripPos, zStripPos;
+                //Find intersection of the strip with the z=centerOfSensor plane to set it as the center of the SET strip
+                dd4hep::rec::Vector3D simHitPosSmeared = (1./dd4hep::mm) * ( surf->localToGlobal( dd4hep::rec::Vector2D( (uL+uSmear)*dd4hep::mm, 0.) ) );
+                zStripPos = surf->origin()[2] / dd4hep::mm ;
+                double lineParam = (zStripPos - simHitPosSmeared[2])/v[2];
+                xStripPos = simHitPosSmeared[0] + lineParam*v[0];
+                yStripPos = simHitPosSmeared[1] + lineParam*v[1];
+                newPosTmp = dd4hep::rec::Vector3D(xStripPos, yStripPos, zStripPos);    
+            }
+            else{
+                newPosTmp = (1./dd4hep::mm) * ( surf->localToGlobal( dd4hep::rec::Vector2D( (uL+uSmear)*dd4hep::mm, 0. ) ) );    
+            }
         }
         else{
-            newPosTmp = (1./dd4hep::mm) * ( surf->localToGlobal( dd4hep::rec::Vector2D( (uL+uSmear)*dd4hep::mm, 0. ) ) );
+            newPosTmp = (1./dd4hep::mm) * ( surf->localToGlobal( dd4hep::rec::Vector2D( (uL+uSmear)*dd4hep::mm, (vL+vSmear)*dd4hep::mm ) ) );
         }
 
         streamlog_out( DEBUG1 ) << " hit at    : " << oldPos 

--- a/source/Digitisers/src/DDSpacePointBuilder.cc
+++ b/source/Digitisers/src/DDSpacePointBuilder.cc
@@ -511,10 +511,20 @@ TrackerHitImpl* DDSpacePointBuilder::createSpacePoint( TrackerHitPlane* a , Trac
   //streamlog_out(DEBUG3) << " L1 = " << L1 << std::endl;
   //streamlog_out(DEBUG3) << " L2 = " << L2 << std::endl;
 
-  dd4hep::rec::Vector2D ddSL1( L1.u(),(-stripLength * dd4hep::mm)/2.0 );
-  dd4hep::rec::Vector2D ddEL1( L1.u(),(stripLength * dd4hep::mm)/2.0 );
-  dd4hep::rec::Vector2D ddSL2( L2.u(),(-stripLength * dd4hep::mm)/2.0 );
-  dd4hep::rec::Vector2D ddEL2( L2.u(),(stripLength * dd4hep::mm)/2.0 );
+  dd4hep::rec::Vector2D ddSL1, ddEL1, ddSL2, ddEL2;
+  if (_subDetName == "SET"){
+      ddSL1 = dd4hep::rec::Vector2D( L1.u(), L1.v() + (-stripLength * dd4hep::mm)/2.0 );
+      ddEL1 = dd4hep::rec::Vector2D( L1.u(), L1.v() + (stripLength * dd4hep::mm)/2.0 );
+      ddSL2 = dd4hep::rec::Vector2D( L2.u(), L2.v() + (-stripLength * dd4hep::mm)/2.0 );
+      ddEL2 = dd4hep::rec::Vector2D( L2.u(), L2.v() + (stripLength * dd4hep::mm)/2.0 );
+  }
+  else{
+      ddSL1 = dd4hep::rec::Vector2D( L1.u(), (-stripLength * dd4hep::mm)/2.0 );
+      ddEL1 = dd4hep::rec::Vector2D( L1.u(), (stripLength * dd4hep::mm)/2.0 );
+      ddSL2 = dd4hep::rec::Vector2D( L2.u(), (-stripLength * dd4hep::mm)/2.0 );
+      ddEL2 = dd4hep::rec::Vector2D( L2.u(), (stripLength * dd4hep::mm)/2.0 );        
+  }
+
   //L1.setY(-stripLength/2.0);
   //CLHEP::Hep3Vector SL1 = L1;
   //L1.setY( stripLength/2.0);
@@ -898,6 +908,3 @@ std::string DDSpacePointBuilder::getCellID0Info( int cellID0 ){
   return s.str();
   
 }
-
-
-

--- a/source/Digitisers/src/DDSpacePointBuilder.cc
+++ b/source/Digitisers/src/DDSpacePointBuilder.cc
@@ -64,24 +64,7 @@ DDSpacePointBuilder::DDSpacePointBuilder() : Processor("DDSpacePointBuilder") {
                             "Name of the SpacePoint SimTrackerHit relation collection",
                             _relColName,
                             std::string("FTDSimHitSpacepointRelations"));
-    
-   
-  registerProcessorParameter("NominalVertexX",
-                             "The global x coordinate of the nominal vertex used for calculation of strip hit intersections",
-                             _nominal_vertex_x,
-                             float(0.0));
 
-  
-  registerProcessorParameter("NominalVertexY",
-                             "The global x coordinate of the nominal vertex used for calculation of strip hit intersections",
-                             _nominal_vertex_y,
-                             float(0.0));
-
-  
-  registerProcessorParameter("NominalVertexZ",
-                             "The global x coordinate of the nominal vertex used for calculation of strip hit intersections",
-                             _nominal_vertex_z,
-                             float(0.0));
    
   // YV added
   registerProcessorParameter("StripLength",
@@ -115,8 +98,6 @@ void DDSpacePointBuilder::init() {
 
   _nRun = 0 ;
   _nEvt = 0 ;
-
-  _nominal_vertex.set(_nominal_vertex_x, _nominal_vertex_y, _nominal_vertex_z);
   
   MarlinTrk::IMarlinTrkSystem* trksystem =  MarlinTrk::Factory::createMarlinTrkSystem( "DDKalTest" , 0, "" ) ;
   


### PR DESCRIPTION

BEGINRELEASENOTES

- Center of the SET strips is now properly in the middle of the sensor modules.
- Removed unused `vertex_x`, `vertex_y`, `vertex_z` steering parameters.

ENDRELEASENOTES

### Description
This is the fix for the #50 and small optimization mentioned here #54.

Everything is carefully wrapped into `if (_subDetName == "SET")` to not affect reconstruction of the VXD/SIT/FTD hits until further investigation if those are affected and any corrections are needed.

### Note
Current change would be impossible for the FTD because FTD strips are perpendicular to the `z` which would give infinity in division by `v[2]`. So even if correction is needed there, then the math would be different.
Not sure what happens inside VXD or SIT...

### Control plots

TODO
