### PR TITLE
Intialize potentially unused pointer to avoid seg faults

### DIFF
--- a/source/Refitting/include/SiliconTracking_MarlinTrk.h
+++ b/source/Refitting/include/SiliconTracking_MarlinTrk.h
@@ -258,7 +258,7 @@ protected:
   // histogram member variables
   
   bool  _createDiagnosticsHistograms;
-  DiagnosticsHistograms::Histograms* _histos ;
+  DiagnosticsHistograms::Histograms* _histos{nullptr};
 
   
   int _ntriplets, _ntriplets_good, _ntriplets_2MCP, _ntriplets_3MCP, _ntriplets_1MCP_Bad, _ntriplets_bad;


### PR DESCRIPTION

BEGINRELEASENOTES
- Make sure that the `_histos` pointer is at least initialized to a `nullptr` to avoid a spurious seg fault when trying to delete it uninitialized.

ENDRELEASENOTES