### PR TITLE
Update ci

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -5,27 +5,14 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     strategy:
+      matrix:
+        build_type: ["release", "nightly"]
+        image: ["alma9", "ubuntu22", "centos7"]
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
-    - uses: aidasoft/run-lcg-view@v4
+    - uses: actions/checkout@v4
+    - uses: key4hep/key4hep-actions/key4hep-build@main
       with:
-        container: centos7
-        view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
-        run: |
-          mkdir build
-          cd build
-          echo "::group::Run CMake"
-          cmake -GNinja \
-            -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " \
-            -DCMAKE_CXX_STANDARD=17 \
-            -DCMAKE_INSTALL_PREFIX=../install \
-            ..
-          echo "::endgroup::" && echo "::group::Build"
-          ninja -k0
-          echo "::endgroup::" && echo "::group::Run Tests"
-          ctest --output-on-failure
-          echo "::endgroup::" && echo "::group::Install"
-          ninja install
+        build_type: ${{ matrix.build_type }}
+        image: ${{ matrix.image }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,11 +7,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        COMPILER: [gcc10, clang11]
-        LCG: [100]
+        COMPILER: [gcc11]
+        LCG: [104]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:
@@ -20,7 +20,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -GNinja -C ${ILCSOFT}/ILCSoft.cmake -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -DINSTALL_DOC=ON ..
+          cmake -GNinja -C ${ILCSOFT}/ILCSoft.cmake -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " ..
           ninja -k0
           ctest --output-on-failure
           ninja install


### PR DESCRIPTION
BEGINRELEASENOTES
- Switch to the `key4hep-build` github action for building against key4hep stacks
- Update the clicdp nightlies based workflow to the latest available version of the nightlies

ENDRELEASENOTES