### PR TITLE
Fix warnings and remove CentOS7 from CI workflows

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         build_type: ["release", "nightly"]
-        image: ["alma9", "ubuntu22", "centos7"]
+        image: ["alma9", "ubuntu22"]
       fail-fast: false
 
     steps:

--- a/source/Digitisers/include/DDPlanarDigiProcessor.h
+++ b/source/Digitisers/include/DDPlanarDigiProcessor.h
@@ -61,6 +61,8 @@ public:
   
   
   DDPlanarDigiProcessor() ;
+  DDPlanarDigiProcessor(const DDPlanarDigiProcessor&) = delete;
+  DDPlanarDigiProcessor& operator=(const DDPlanarDigiProcessor&) = delete;
   
   /** Called at the begin of the job before anything is read.
    * Use to initialize the processor, e.g. book histograms.
@@ -88,35 +90,35 @@ public:
   
 protected:
   
-  std::string _inColName ;
+  std::string _inColName {};
   
-  std::string _outColName ;
-  std::string _outRelColName ;
+  std::string _outColName {};
+  std::string _outRelColName {};
  
-  std::string _subDetName ;
+  std::string _subDetName {};
   
-  int _nRun ;
-  int _nEvt ;
+  int _nRun {};
+  int _nEvt {};
   
-  FloatVec _resU ;
-  FloatVec _resV ;
-  FloatVec _resT ;
+  FloatVec _resU {};
+  FloatVec _resV {};
+  FloatVec _resT {};
   
-  bool _isStrip;
+  bool _isStrip{};
   
-  gsl_rng* _rng ;
+  gsl_rng* _rng {nullptr};
   
-  const dd4hep::rec::SurfaceMap* _map ;
+  const dd4hep::rec::SurfaceMap* _map {nullptr};
 
-  bool _forceHitsOntoSurface  ;
-  double _minEnergy ;
+  bool _forceHitsOntoSurface {};
+  double _minEnergy {};
 
-  bool _useTimeWindow ;
-  bool _correctTimesForPropagation ;
-  FloatVec _timeWindow_min ;
-  FloatVec _timeWindow_max ;
+  bool _useTimeWindow {};
+  bool _correctTimesForPropagation {};
+  FloatVec _timeWindow_min {};
+  FloatVec _timeWindow_max {};
 
-  std::vector<TH1F*> _h ;
+  std::vector<TH1F*> _h {};
   
 } ;
 

--- a/source/Digitisers/include/DDSpacePointBuilder.h
+++ b/source/Digitisers/include/DDSpacePointBuilder.h
@@ -71,6 +71,9 @@ class DDSpacePointBuilder : public Processor {
   
   
   DDSpacePointBuilder() ;
+
+  DDSpacePointBuilder(const DDSpacePointBuilder&) = delete;
+  DDSpacePointBuilder& operator=(const DDSpacePointBuilder&) = delete;
   
   /** Called at the begin of the job before anything is read.
    * Use to initialize the processor, e.g. book histograms.
@@ -102,19 +105,19 @@ class DDSpacePointBuilder : public Processor {
 
   /** Input collection name.
   */
-  std::string _TrackerHitCollection;
+  std::string _TrackerHitCollection{};
 
   /** Input relation collection name.
    */
-  std::string _TrackerHitSimHitRelCollection;
+  std::string _TrackerHitSimHitRelCollection{};
   
   /** Output collection name.
   */
-  std::string _SpacePointsCollection;
+  std::string _SpacePointsCollection{};
   
   /** Output relations collection name.
    */
-  std::string _relColName;
+  std::string _relColName{};
 
   /** Calculates the 2 dimensional crossing point of two lines.
    * Each line is specified by a point (x,y) and a direction vector (ex,ey).
@@ -196,26 +199,26 @@ class DDSpacePointBuilder : public Processor {
   std::string getCellID0Info( int cellID0 );
  
 
-  int _nRun ;
-  int _nEvt ;
+  int _nRun {};
+  int _nEvt {};
 
-  unsigned _nOutOfBoundary;
-  unsigned _nStripsTooParallel;
-  unsigned _nPlanesNotParallel;
+  unsigned _nOutOfBoundary{};
+  unsigned _nStripsTooParallel{};
+  unsigned _nPlanesNotParallel{};
 
-  float _nominal_vertex_x;
-  float _nominal_vertex_y;
-  float _nominal_vertex_z;
+  float _nominal_vertex_x{};
+  float _nominal_vertex_y{};
+  float _nominal_vertex_z{};
 
-  CLHEP::Hep3Vector _nominal_vertex;
+  CLHEP::Hep3Vector _nominal_vertex{};
 
-  float _striplength_tolerance;
+  float _striplength_tolerance{};
 
-  double _striplength ;
-  std::string _subDetName ;
+  double _striplength {};
+  std::string _subDetName {};
 
   //dd4hep::Detector& lcdd;
-  const dd4hep::rec::SurfaceMap* surfMap ;
+  const dd4hep::rec::SurfaceMap* surfMap {nullptr};
   
 } ;
 

--- a/source/Digitisers/include/DDTPCDigiProcessor.h
+++ b/source/Digitisers/include/DDTPCDigiProcessor.h
@@ -119,6 +119,9 @@ public:
   
   DDTPCDigiProcessor() ;
 
+  DDTPCDigiProcessor(const DDTPCDigiProcessor&) = delete;
+  DDTPCDigiProcessor& operator=(const DDTPCDigiProcessor&) = delete;
+
   ~DDTPCDigiProcessor() ;
   
   /** Called at the begin of the job before anything is read.

--- a/source/Digitisers/src/FixedPadSizeDiskLayout.cc
+++ b/source/Digitisers/src/FixedPadSizeDiskLayout.cc
@@ -147,7 +147,7 @@ double FixedPadSizeDiskLayout::getPadWidth(int padIndex) const {
     return _padWidth / _rows.at( rowNum ).RCenter ;
 
   }
-  catch(std::out_of_range){
+  catch(std::out_of_range&){
     return 0. ;
   }
 }
@@ -162,7 +162,7 @@ double FixedPadSizeDiskLayout::getPadPitch(int padIndex) const {
     return _rows.at( rowNum ).PhiPad;
 
   }
-  catch(std::out_of_range){
+  catch(std::out_of_range&){
     return 0. ;
   }
 }

--- a/source/Digitisers/src/TPCModularEndplate.h
+++ b/source/Digitisers/src/TPCModularEndplate.h
@@ -29,7 +29,8 @@ public:
 
   /// no default c'tor
   TPCModularEndplate() = delete ;
-  
+  TPCModularEndplate(const TPCModularEndplate&) = delete;
+  TPCModularEndplate& operator=(const TPCModularEndplate&) = delete;
 
   /// intitialize for the gice TPC data
   TPCModularEndplate( const dd4hep::rec::FixedPadSizeTPCData* tpc ) ;

--- a/source/Refitting/include/ClonesAndSplitTracksFinder.h
+++ b/source/Refitting/include/ClonesAndSplitTracksFinder.h
@@ -75,8 +75,8 @@ protected:
 
   lcio::LCCollection* GetCollection(lcio::LCEvent* evt, std::string colName);
 
-  std::string _input_track_col_name;
-  std::string _output_track_col_name;
+  std::string _input_track_col_name{};
+  std::string _output_track_col_name{};
 
   MarlinTrk::IMarlinTrkSystem* _trksystem = nullptr;
 
@@ -95,12 +95,12 @@ protected:
   bool _mergeSplitTracks = false;
 
   // Track fit parameters
-  double _initialTrackError_d0;
-  double _initialTrackError_phi0;
-  double _initialTrackError_omega;
-  double _initialTrackError_z0;
-  double _initialTrackError_tanL;
-  double _maxChi2perHit;
+  double _initialTrackError_d0{};
+  double _initialTrackError_phi0{};
+  double _initialTrackError_omega{};
+  double _initialTrackError_z0{};
+  double _initialTrackError_tanL{};
+  double _maxChi2perHit{};
 
   std::shared_ptr<UTIL::BitField64> _encoder{};
 };

--- a/source/Refitting/include/DDCellsAutomatonMV.h
+++ b/source/Refitting/include/DDCellsAutomatonMV.h
@@ -87,6 +87,8 @@ class DDCellsAutomatonMV : public Processor {
   
   
   DDCellsAutomatonMV() ;
+  DDCellsAutomatonMV(const DDCellsAutomatonMV&) = delete ;
+  DDCellsAutomatonMV& operator=(const DDCellsAutomatonMV&) = delete ;
   
   /** Called at the begin of the job before anything is read.
    * Use to initialize the processor, e.g. book histograms.
@@ -113,29 +115,30 @@ class DDCellsAutomatonMV : public Processor {
 
 
  protected:
+  int nEvt{};
 
-  int nEvt;
+  int _nDivisionsInPhi{};
+  int _nDivisionsInTheta{};
+  int _nDivisionsInPhiMV{};
+  int _nDivisionsInThetaMV{};
+  int _nLayers{};
 
-  int _nDivisionsInPhi;
-  int _nDivisionsInTheta;
-  int _nDivisionsInPhiMV;
-  int _nDivisionsInThetaMV;
-  int _nLayers;
-
-  float _bField;
+  float _bField{};
 
   // two pi is not a constant in cmath. Calculate it, once!
   static const double TWOPI;
-  double _dPhi;
-  double _dTheta;
-
-  UTIL::BitField64* _encoder;
+  UTIL::BitField64* _encoder{nullptr};
   int getDetectorID(TrackerHit* hit) { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::subdet()]; }
   int getSideID(TrackerHit* hit)     { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::side()]; };
   int getLayerID(TrackerHit* hit)    { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::layer()]; };
   int getModuleID(TrackerHit* hit)   { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::module()]; };
   int getSensorID(TrackerHit* hit)   { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::sensor()]; };
   
+  double _dPhi{};
+  double _dTheta{};
+
+  unsigned int _nLayersVTX{};
+  unsigned int _nLayersSIT{};
 
   void InitialiseVTX(LCEvent * evt, EVENT::TrackerHitVec HitsTemp);
   void setupGeom() ;
@@ -148,107 +151,100 @@ class DDCellsAutomatonMV : public Processor {
   bool thetaAgreementImproved( EVENT::TrackerHit *toHit, EVENT::TrackerHit *fromHit, int layer ) ;
   double Dist( EVENT::TrackerHit *toHit, EVENT::TrackerHit *fromHit ) ;
 
-  unsigned int _nLayersVTX;
-  unsigned int _nLayersSIT;
-  
   /** A map to store the hits according to their sectors */
-  std::map< int , EVENT::TrackerHitVec > _map_sector_spacepoints;
-  std::map< int , std::vector< IHit* > > _map_sector_hits;
-  
-  /** Names of the used criteria */
-  std::vector< std::string > _criteriaNames;
-   
-  /** Map containing the name of a criterion and a vector of the minimum cut offs for it */
-  std::map< std::string , std::vector<float> > _critMinima;
-  
-  /** Map containing the name of a criterion and a vector of the maximum cut offs for it */
-  std::map< std::string , std::vector<float> > _critMaxima;
-  
-  /** Minimum number of hits a track has to have in order to be stored */
-  int _hitsPerTrackMin;
-  
-  /** A vector of criteria for 2 hits (2 1-hit segments) */
-  std::vector <ICriterion*> _crit2Vec;
-  
-  /** A vector of criteria for 3 hits (2 2-hit segments) */
-  std::vector <ICriterion*> _crit3Vec;
-  
-  /** A vector of criteria for 4 hits (2 3-hit segments) */
-  std::vector <ICriterion*> _crit4Vec;
+  std::map<int, EVENT::TrackerHitVec> _map_sector_spacepoints{};
+  std::map<int, std::vector<IHit*>> _map_sector_hits{};
 
-  std::vector< IHit* > MiniVectorsTemp;
-  std::vector< IHit* > TestMiniVectorsTemp;
+  /** Names of the used criteria */
+  std::vector<std::string> _criteriaNames{};
+
+  /** Map containing the name of a criterion and a vector of the minimum cut offs for it */
+  std::map<std::string, std::vector<float>> _critMinima{};
+
+  /** Map containing the name of a criterion and a vector of the maximum cut offs for it */
+  std::map<std::string, std::vector<float>> _critMaxima{};
+
+  /** Minimum number of hits a track has to have in order to be stored */
+  int _hitsPerTrackMin{};
+
+  /** A vector of criteria for 2 hits (2 1-hit segments) */
+  std::vector<ICriterion*> _crit2Vec{};
+
+  /** A vector of criteria for 3 hits (2 2-hit segments) */
+  std::vector<ICriterion*> _crit3Vec{};
+
+  /** A vector of criteria for 4 hits (2 3-hit segments) */
+  std::vector<ICriterion*> _crit4Vec{};
+
+  std::vector<IHit*> MiniVectorsTemp{};
+  std::vector<IHit*> TestMiniVectorsTemp{};
 
   /** Cut for the Kalman Fit (the chi squared probability) */
-  double _chi2ProbCut;  
+  double _chi2ProbCut{};
 
-  double _helixFitMax ;
+  double _helixFitMax{};
 
-  double _chi2OverNdfCut ;
+  double _chi2OverNdfCut{};
 
-  const SectorSystemVXD * _sectorSystemVXD;
-   
+  const SectorSystemVXD* _sectorSystemVXD{nullptr};
+
   /** the maximum number of connections that are allowed in the automaton, if this value is surpassed, rerun
    * the automaton with tighter cuts or stop it entirely. */
-  int _maxConnectionsAutomaton;
-  
-  MarlinTrk::IMarlinTrkSystem* _trkSystem;
-  
-  bool _MSOn, _ElossOn, _SmoothOn, _middleLayer ;
+  int _maxConnectionsAutomaton{};
 
-  int _useSIT ;
+  MarlinTrk::IMarlinTrkSystem* _trkSystem{nullptr};
 
-  int _layerStepMax ;
+  bool _MSOn{}, _ElossOn{}, _SmoothOn{}, _middleLayer{};
 
-  int _lastLayerToIP ;
+  int _useSIT{};
 
-  int _nHitsChi2 ;
+  int _layerStepMax{};
 
-  int MiniVectors_sectors ;
-  int MiniVectors_CutSelection ;
+  int _lastLayerToIP{};
 
-  FloatVec _resU ;
+  int _nHitsChi2{};
 
-  double _maxDist ;
-  double _hitPairThDiff ;
-  double _hitPairThDiffInner ;
-  
-  //std::vector< MarlinTrk::IMarlinTrack* > GoodTracks;
-  //std::vector< MarlinTrk::IMarlinTrack* > RejectedTracks;
+  int MiniVectors_sectors{};
+  int MiniVectors_CutSelection{};
 
+  FloatVec _resU{};
 
-  
-  float _initialTrackError_d0;
-  float _initialTrackError_phi0;
-  float _initialTrackError_omega;
-  float _initialTrackError_z0;
-  float _initialTrackError_tanL;
-  float _maxChi2PerHit;
+  double _maxDist{};
+  double _hitPairThDiff{};
+  double _hitPairThDiffInner{};
 
-  int _maxHitsPerSector ;
-  
+  // std::vector< MarlinTrk::IMarlinTrack* > GoodTracks;
+  // std::vector< MarlinTrk::IMarlinTrack* > RejectedTracks;
+
+  float _initialTrackError_d0{};
+  float _initialTrackError_phi0{};
+  float _initialTrackError_omega{};
+  float _initialTrackError_z0{};
+  float _initialTrackError_tanL{};
+  float _maxChi2PerHit{};
+
+  int _maxHitsPerSector{};
+
   /** Input collection name.
    */
-  std::string _VTXHitCollection;
-  std::string _SITHitCollection;
-  std::string _CATrackCollection;
+  std::string _VTXHitCollection{};
+  std::string _SITHitCollection{};
+  std::string _CATrackCollection{};
 
-  std::string _detElVXDName;
-  std::string _detElITName;
-  std::string _detElOTName;
+  std::string _detElVXDName{};
+  std::string _detElITName{};
+  std::string _detElOTName{};
 
-  
-  std::map< LCCollection*, std::string > _colNamesTrackerHits;
-  
-  std::string _bestSubsetFinder;
+  std::map<LCCollection*, std::string> _colNamesTrackerHits{};
 
-   /** The quality of the output track collection */
-   int _output_track_col_quality ; 
-  
-   static const int _output_track_col_quality_GOOD;
-   static const int _output_track_col_quality_FAIR;
-   static const int _output_track_col_quality_POOR;
+  /** The quality of the output track collection */
+  int _output_track_col_quality{};
 
+  static const int _output_track_col_quality_GOOD;
+  static const int _output_track_col_quality_FAIR;
+  static const int _output_track_col_quality_POOR;
+
+  std::string _bestSubsetFinder{};
 
 } ;
 

--- a/source/Refitting/include/ExtrToSIT.h
+++ b/source/Refitting/include/ExtrToSIT.h
@@ -57,6 +57,8 @@ public:
   virtual marlin::Processor*  newProcessor() { return new ExtrToSIT ; }
   
   ExtrToSIT() ;
+  ExtrToSIT(const ExtrToSIT&) = delete;
+  ExtrToSIT& operator=(const ExtrToSIT&) = delete;
   
   /** Called at the begin of the job before anything is read.
    * Use to initialize the processor, e.g. book histograms.
@@ -106,35 +108,35 @@ protected:
   
   /** Input track collection name for refitting.
    */
-  std::string _input_track_col_name ;
+  std::string _input_track_col_name {};
   
   /** Input track relations name for refitting.
    */
-  std::string _input_track_rel_name ;
+  std::string _input_track_rel_name {};
 
   /** Input SIT tracker summer hit collection.
    */
-  std::string _sitColName ;
+  std::string _sitColName {};
 
   /** Input VXD tracker summer hit collection.
    */
-  std::string _vxdColName ;
+  std::string _vxdColName {};
   
   /** refitted track collection name.
    */
-  std::string _output_track_col_name ;
+  std::string _output_track_col_name {};
   
   /** Output track relations name for refitting.
    */
-  std::string _output_track_rel_name ;
+  std::string _output_track_rel_name {};
 
   /** Output silicon track collection.
    */
-  std::string _siTrkColName ;
+  std::string _siTrkColName {};
   
   /** pointer to the IMarlinTrkSystem instance 
    */
-  MarlinTrk::IMarlinTrkSystem* _trksystem{} ;
+  MarlinTrk::IMarlinTrkSystem* _trksystem{nullptr} ;
   std::string _trkSystemName{} ;
   
   std::string _mcParticleCollectionName{} ;

--- a/source/Refitting/include/ExtrToTracker.h
+++ b/source/Refitting/include/ExtrToTracker.h
@@ -69,6 +69,8 @@ public:
   virtual marlin::Processor*  newProcessor() { return new ExtrToTracker ; }
   
   ExtrToTracker() ;
+  ExtrToTracker(const ExtrToTracker&) = delete;
+  ExtrToTracker& operator=(const ExtrToTracker&) = delete;
 
   /** Called at the begin of the job before anything is read.
    * Use to initialize the processor, e.g. book histograms.
@@ -140,63 +142,63 @@ protected:
   
   /** Input track collection name for refitting.
    */
-  std::string _input_track_col_name ;
+  std::string _input_track_col_name {};
   
 
   /** output collection name for the not used hits.
    */
-  std::string _output_not_used_col_name ;
+  std::string _output_not_used_col_name {};
   
   /** output track collection name.
    */
-  std::string _output_track_col_name ;
+  std::string _output_track_col_name {};
   
   /** Output track relations name for refitting.
    */
-  std::string _output_track_rel_name ;
+  std::string _output_track_rel_name {};
   
   /** pointer to the IMarlinTrkSystem instance 
    */
-  MarlinTrk::IMarlinTrkSystem* _trksystem ;
+  MarlinTrk::IMarlinTrkSystem* _trksystem {nullptr};
   
   /* std::string _mcParticleCollectionName ; */
 
-  bool _MSOn ;
-  bool _ElossOn ;
-  bool _SmoothOn ;
-  double _Max_Chi2_Incr ;
-  double _searchSigma ;
+  bool _MSOn {};
+  bool _ElossOn {};
+  bool _SmoothOn {};
+  double _Max_Chi2_Incr {};
+  double _searchSigma {};
   
-  int _n_run ;
-  int _n_evt ;
-  int SITHitsFitted ;
-  int SITHitsNonFitted ;
-  int TotalSITHits ;
-  int _nHitsChi2 ;
+  int _n_run {};
+  int _n_evt {};
+  int SITHitsFitted {};
+  int SITHitsNonFitted {};
+  int TotalSITHits {};
+  int _nHitsChi2 {};
 
-  float _bField;
+  float _bField{};
 
-  bool _performFinalRefit ;
+  bool _performFinalRefit {};
  
-  bool _extrapolateForward;
+  bool _extrapolateForward{};
 
-  const dd4hep::rec::SurfaceMap* _map ;
+  const dd4hep::rec::SurfaceMap* _map {nullptr};
 
   
 
   //processor parameters
 
-  StringVec _vecDigiHits;
-  StringVec _vecSubdetName;
-  std::vector<bool > _vecSubdetIsBarrel;
-  std::vector<int > _vecSubdetNLayers;
-  std::vector<int > _vecSubdetID;
-  std::vector<LCCollection* > _vecDigiHitsCol;
-  std::vector<std::map<dd4hep::CellID , std::vector<dd4hep::CellID > >* >  _vecMapNeighbours;
+  StringVec _vecDigiHits{};
+  StringVec _vecSubdetName{};
+  std::vector<bool > _vecSubdetIsBarrel{};
+  std::vector<int > _vecSubdetNLayers{};
+  std::vector<int > _vecSubdetID{};
+  std::vector<LCCollection* > _vecDigiHitsCol{};
+  std::vector<std::map<dd4hep::CellID , std::vector<dd4hep::CellID > >* >  _vecMapNeighbours{};
 
-  std::vector<std::map<int , std::vector<TrackerHitPlane* > > > _vecMapsElHits;
+  std::vector<std::map<int , std::vector<TrackerHitPlane* > > > _vecMapsElHits{};
 
-  std::vector<std::vector<TrackerHitPlane* > > _vecvecHitsInCol;
+  std::vector<std::vector<TrackerHitPlane* > > _vecvecHitsInCol{};
  
  
 } ;

--- a/source/Refitting/include/FPCCDFullLDCTracking_MarlinTrk.h
+++ b/source/Refitting/include/FPCCDFullLDCTracking_MarlinTrk.h
@@ -301,7 +301,9 @@ class FPCCDFullLDCTracking_MarlinTrk : public Processor {
 public:
   
   virtual Processor*  newProcessor() { return new FPCCDFullLDCTracking_MarlinTrk ; }  
-  FPCCDFullLDCTracking_MarlinTrk() ;  
+  FPCCDFullLDCTracking_MarlinTrk() ;
+  FPCCDFullLDCTracking_MarlinTrk(const FPCCDFullLDCTracking_MarlinTrk&) = delete ;
+  FPCCDFullLDCTracking_MarlinTrk& operator=(const FPCCDFullLDCTracking_MarlinTrk&) = delete ;
   virtual void init() ;
   virtual void processRunHeader( LCRunHeader* run ) ;
   virtual void processEvent( LCEvent * evt ) ; 
@@ -360,126 +362,126 @@ protected:
   bool VetoMerge(TrackExtended* firstTrackExt, TrackExtended* secondTrackExt);
   
   
-  int _nRun ;
-  int _nEvt ;
+  int _nRun {};
+  int _nEvt {};
   
-  MarlinTrk::HelixFit* _fastfitter;
+  MarlinTrk::HelixFit* _fastfitter{nullptr};
   
   /** pointer to the IMarlinTrkSystem instance 
    */
-  MarlinTrk::IMarlinTrkSystem* _trksystem ;
+  MarlinTrk::IMarlinTrkSystem* _trksystem {nullptr};
   
-  bool _MSOn, _ElossOn, _SmoothOn ;
+  bool _MSOn{}, _ElossOn{}, _SmoothOn {};
   
-  std::string _TPCTrackCollection;
-  std::string _SiTrackCollection;
-  std::string _TPCTrackMCPCollName;
-  std::string _SiTrackMCPCollName;
+  std::string _TPCTrackCollection{};
+  std::string _SiTrackCollection{};
+  std::string _TPCTrackMCPCollName{};
+  std::string _SiTrackMCPCollName{};
   
-  std::string _VTXTrackerHitCollection;
-  std::string _SITTrackerHitCollection;
-  std::string _SETTrackerHitCollection;
-  std::string _FTDPixelHitCollection;
-  std::string _FTDSpacePointCollection;
-  std::string _TPCTrackerHitCollection;
-  std::string _ETDTrackerHitCollection;
+  std::string _VTXTrackerHitCollection{};
+  std::string _SITTrackerHitCollection{};
+  std::string _SETTrackerHitCollection{};
+  std::string _FTDPixelHitCollection{};
+  std::string _FTDSpacePointCollection{};
+  std::string _TPCTrackerHitCollection{};
+  std::string _ETDTrackerHitCollection{};
   
-  std::string _LDCTrackCollection;
-  
-  
-  TrackExtendedVec _allSiTracks;
-  TrackExtendedVec _allTPCTracks;
-  TrackExtendedVec _allCombinedTracks;
-  TrackExtendedVec _allNonCombinedTPCTracks;
-  TrackExtendedVec _allNonCombinedSiTracks;
-  TrackExtendedVec _trkImplVec;
-  TrackerHitExtendedVec _allTPCHits;
-  TrackerHitExtendedVec _allVTXHits;
-  TrackerHitExtendedVec _allFTDHits;
-  TrackerHitExtendedVec _allSITHits;
-  TrackerHitExtendedVec _allSETHits;
-  TrackerHitExtendedVec _allETDHits;
-  
-  float PI, PIOVER2, TWOPI;
-  
-  float _bField;
-  float _chi2PrefitCut;
-  float _chi2FitCut;
-  
-  int _debug;
-  
-  float _dPCutForMerging;
-  float _d0CutForMerging;
-  float _z0CutForMerging;
-  float _dOmegaForMerging;
-  float _angleForMerging;
+  std::string _LDCTrackCollection{};
   
   
-  int   _forceMerging;
-  float _dPCutForForcedMerging;
-  float _d0CutForForcedMerging;
-  float _z0CutForForcedMerging;
-  float _dOmegaForForcedMerging;
-  float _angleForForcedMerging;
+  TrackExtendedVec _allSiTracks{};
+  TrackExtendedVec _allTPCTracks{};
+  TrackExtendedVec _allCombinedTracks{};
+  TrackExtendedVec _allNonCombinedTPCTracks{};
+  TrackExtendedVec _allNonCombinedSiTracks{};
+  TrackExtendedVec _trkImplVec{};
+  TrackerHitExtendedVec _allTPCHits{};
+  TrackerHitExtendedVec _allVTXHits{};
+  TrackerHitExtendedVec _allFTDHits{};
+  TrackerHitExtendedVec _allSITHits{};
+  TrackerHitExtendedVec _allSETHits{};
+  TrackerHitExtendedVec _allETDHits{};
+  
+  float PI{}, PIOVER2{}, TWOPI{};
+  
+  float _bField{};
+  float _chi2PrefitCut{};
+  float _chi2FitCut{};
+  
+  int _debug{};
+  
+  float _dPCutForMerging{};
+  float _d0CutForMerging{};
+  float _z0CutForMerging{};
+  float _dOmegaForMerging{};
+  float _angleForMerging{};
   
   
-  int _mergeTPCSegments;
-  float _dPCutToMergeTPC;
-  float _PtCutToMergeTPC;
-  float _d0CutToMergeTPC;
-  float _z0CutToMergeTPC;
-  
-  float _cosThetaCutHighPtMerge;
-  float _cosThetaCutSoftHighPtMerge;
-  float _momDiffCutHighPtMerge;
-  float _momDiffCutSoftHighPtMerge;
-  float _hitDistanceCutHighPtMerge;
-  float _maxHitDistanceCutHighPtMerge;
-  float _maxFractionOfOutliersCutHighPtMerge;
-  
-  float _vetoMergeMomentumCut;
-  
-  float _initialTrackError_d0;
-  float _initialTrackError_phi0;
-  float _initialTrackError_omega;
-  float _initialTrackError_z0;
-  float _initialTrackError_tanL;
-  
-  double _maxChi2PerHit;
-  double _minChi2ProbForSiliconTracks;
-  double _maxChi2ForSiliconTracks;
-  bool   _useMaxChi2ReqForSiTrk;
-  float  _maxAllowedPercentageOfOutliersForTrackCombination;
-  int    _maxAllowedSiHitRejectionsForTrackCombination;
-  
-  bool _runMarlinTrkDiagnostics;
-  std::string _MarlinTrkDiagnosticsName;
-  
-  int _nHitsExtrapolation;
-  
-  int _cutOnTPCHits;
-  int _cutOnSiHits;
+  int   _forceMerging{};
+  float _dPCutForForcedMerging{};
+  float _d0CutForForcedMerging{};
+  float _z0CutForForcedMerging{};
+  float _dOmegaForForcedMerging{};
+  float _angleForForcedMerging{};
   
   
-  int _assignVTXHits,_assignFTDHits,_assignSITHits,_assignTPCHits;
+  int _mergeTPCSegments{};
+  float _dPCutToMergeTPC{};
+  float _PtCutToMergeTPC{};
+  float _d0CutToMergeTPC{};
+  float _z0CutToMergeTPC{};
   
-  int _assignSETHits, _assignETDHits;
+  float _cosThetaCutHighPtMerge{};
+  float _cosThetaCutSoftHighPtMerge{};
+  float _momDiffCutHighPtMerge{};
+  float _momDiffCutSoftHighPtMerge{};
+  float _hitDistanceCutHighPtMerge{};
+  float _maxHitDistanceCutHighPtMerge{};
+  float _maxFractionOfOutliersCutHighPtMerge{};
   
-  float _distCutForVTXHits,_distCutForFTDHits,_distCutForSITHits,_distCutForTPCHits;
+  float _vetoMergeMomentumCut{};
   
-  float _distCutForSETHits, _distCutForETDHits;
+  float _initialTrackError_d0{};
+  float _initialTrackError_phi0{};
+  float _initialTrackError_omega{};
+  float _initialTrackError_z0{};
+  float _initialTrackError_tanL{};
+  
+  double _maxChi2PerHit{};
+  double _minChi2ProbForSiliconTracks{};
+  double _maxChi2ForSiliconTracks{};
+  bool   _useMaxChi2ReqForSiTrk{};
+  float  _maxAllowedPercentageOfOutliersForTrackCombination{};
+  int    _maxAllowedSiHitRejectionsForTrackCombination{};
+  
+  bool _runMarlinTrkDiagnostics{};
+  std::string _MarlinTrkDiagnosticsName{};
+  
+  int _nHitsExtrapolation{};
+  
+  int _cutOnTPCHits{};
+  int _cutOnSiHits{};
   
   
-  float _d0TrkCut,_z0TrkCut;
+  int _assignVTXHits{},_assignFTDHits{},_assignSITHits{},_assignTPCHits{};
   
-  int _forbidOverlapInZTPC,_forbidOverlapInZComb;
+  int _assignSETHits{}, _assignETDHits{};
   
-  LCEvent * _evt;
+  float _distCutForVTXHits{},_distCutForFTDHits{},_distCutForSITHits{},_distCutForTPCHits{};
   
-  std::map<TrackExtended*,HelixClass*> _trackExtrapolatedHelix;
-  std::set<TrackExtended*> _candidateCombinedTracks;
+  float _distCutForSETHits{}, _distCutForETDHits{};
   
-  UTIL::BitField64* _encoder;
+  
+  float _d0TrkCut{},_z0TrkCut{};
+  
+  int _forbidOverlapInZTPC{},_forbidOverlapInZComb{};
+  
+  LCEvent * _evt{nullptr};
+  
+  std::map<TrackExtended*,HelixClass*> _trackExtrapolatedHelix{};
+  std::set<TrackExtended*> _candidateCombinedTracks{};
+  
+  UTIL::BitField64* _encoder{nullptr};
   int getDetectorID(TrackerHit* hit) { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::subdet()]; }
   int getSideID(TrackerHit* hit)     { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::side()]; };
   int getLayerID(TrackerHit* hit)    { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::layer()]; };
@@ -495,10 +497,10 @@ protected:
   
   void setupGeom(const dd4hep::Detector& theDetector) ;
   
-  double _tpc_inner_r;
-  double _tpc_outer_r;
-  double _tpc_pad_height;
-  int    _tpc_nrows;
+  double _tpc_inner_r{};
+  double _tpc_outer_r{};
+  double _tpc_pad_height{};
+  int    _tpc_nrows{};
   
 //  struct VXD_Layer {
 //    int nLadders;
@@ -514,7 +516,7 @@ protected:
 //  };
 //  std::vector<VXD_Layer> _VXDgeo;
   
-  unsigned int _nLayersVTX;
+  unsigned int _nLayersVTX{};
   
 //  struct SIT_Layer {
 //    int nLadders;
@@ -530,9 +532,9 @@ protected:
 //  };
 //  std::vector<SIT_Layer> _SITgeo;
   
-  unsigned int _nLayersSIT;
+  unsigned int _nLayersSIT{};
   
-  unsigned int _nLayersSET;
+  unsigned int _nLayersSET{};
 
   
 //  struct FTD_Disk {
@@ -573,11 +575,11 @@ protected:
 //  };
 //  
 //  std::vector<FTD_Disk> _FTDgeo;
-  std::vector<float> _zLayerFTD;
+  std::vector<float> _zLayerFTD{};
   
-  unsigned int _nLayersFTD;
-  int _nPhiFTD; 
-  bool  _petalBasedFTDWithOverlaps;
+  unsigned int _nLayersFTD{};
+  int _nPhiFTD{};
+  bool  _petalBasedFTDWithOverlaps{};
 
 
 
@@ -588,42 +590,42 @@ protected:
 
 /////////////Addition by Mori//////////////////
   
-  GetPurityUtil* _purityUtil;
-  moriUTIL* _moriUtil;
-  MCPMap _mcpMapSi;
-  MCPMap _mcpMapFull;
+  GetPurityUtil* _purityUtil{nullptr};
+  moriUTIL* _moriUtil{nullptr};
+  MCPMap _mcpMapSi{};
+  MCPMap _mcpMapFull{};
   IntVec getNHitsInSubDet(SimTrackerHitVec simvec);
-  std::vector<LCRelationNavigator*> _naviVecSi;
-  std::vector<LCRelationNavigator*> _naviVecFull;
-  std::string _colNameVXDTrackerHitRelations;
-  std::string _colNameSITSpacePointRelations;
-  std::string _colNameFTDSpacePointRelations;
-  std::string _colNameFTDPixelTrackerHitRelations;
-  std::string _colNameTPCTrackerHitRelations;
-  std::string _colNameSETSpacePointRelations;
-  LCRelationNavigator* _navVXD;
-  LCRelationNavigator* _navSIT;
-  LCRelationNavigator* _navFTDsp;
-  LCRelationNavigator* _navFTDpix;
-  LCRelationNavigator* _navTPC;
-  LCRelationNavigator* _navSET;
-  std::string _colNameVXDSimHit;
-  std::string _colNameSITSimHit;
-  std::string _colNameFTDspSimHit;
-  std::string _colNameFTDpixSimHit;
-  std::string _colNameTPCSimHit;
-  std::string _colNameSETSimHit;
-  LCCollection* _simVXD;
-  LCCollection* _simSIT;
-  LCCollection* _simFTDsp;
-  LCCollection* _simFTDpix;
-  LCCollection* _simTPC;
-  LCCollection* _simSET;
+  std::vector<LCRelationNavigator*> _naviVecSi{};
+  std::vector<LCRelationNavigator*> _naviVecFull{};
+  std::string _colNameVXDTrackerHitRelations{};
+  std::string _colNameSITSpacePointRelations{};
+  std::string _colNameFTDSpacePointRelations{};
+  std::string _colNameFTDPixelTrackerHitRelations{};
+  std::string _colNameTPCTrackerHitRelations{};
+  std::string _colNameSETSpacePointRelations{};
+  LCRelationNavigator* _navVXD{nullptr};
+  LCRelationNavigator* _navSIT{nullptr};
+  LCRelationNavigator* _navFTDsp{nullptr};
+  LCRelationNavigator* _navFTDpix{nullptr};
+  LCRelationNavigator* _navTPC{nullptr};
+  LCRelationNavigator* _navSET{nullptr};
+  std::string _colNameVXDSimHit{};
+  std::string _colNameSITSimHit{};
+  std::string _colNameFTDspSimHit{};
+  std::string _colNameFTDpixSimHit{};
+  std::string _colNameTPCSimHit{};
+  std::string _colNameSETSimHit{};
+  LCCollection* _simVXD{nullptr};
+  LCCollection* _simSIT{nullptr};
+  LCCollection* _simFTDsp{nullptr};
+  LCCollection* _simFTDpix{nullptr};
+  LCCollection* _simTPC{nullptr};
+  LCCollection* _simSET{nullptr};
 
-  bool _mydebug;
-  bool _mydebugPrintMCP;
+  bool _mydebug{};
+  bool _mydebugPrintMCP{};
 
-  bool _FinalTrackCut_strategyA;
+  bool _FinalTrackCut_strategyA{};
 
   /** helper function to get collection using try catch block */
   LCCollection* GetCollection(  LCEvent * evt, std::string colName ) ;
@@ -632,13 +634,13 @@ protected:
   LCRelationNavigator* GetRelations( LCEvent * evt, std::string RelName ) ;
 
   MCPMap LoadMCPMap(int mode);
-  std::map< MCParticle*, SimTrackerHitVec > _mcpVXD;
-  std::map< MCParticle*, SimTrackerHitVec > _mcpVXDFTD;
-  std::map< MCParticle*, SimTrackerHitVec > _mcpVXDSIT;
-  std::map< MCParticle*, SimTrackerHitVec > _mcpVXDFTDSIT;
-  std::map< MCParticle*, SimTrackerHitVec > _mcpFTD;
-  std::map< MCParticle*, SimTrackerHitVec > _mcpFTDSIT;
-  std::map< MCParticle*, SimTrackerHitVec > _mcpSIT;
+  std::map< MCParticle*, SimTrackerHitVec > _mcpVXD{};
+  std::map< MCParticle*, SimTrackerHitVec > _mcpVXDFTD{};
+  std::map< MCParticle*, SimTrackerHitVec > _mcpVXDSIT{};
+  std::map< MCParticle*, SimTrackerHitVec > _mcpVXDFTDSIT{};
+  std::map< MCParticle*, SimTrackerHitVec > _mcpFTD{};
+  std::map< MCParticle*, SimTrackerHitVec > _mcpFTDSIT{};
+  std::map< MCParticle*, SimTrackerHitVec > _mcpSIT{};
 
   enum MCPContributions{
      contVXD,

--- a/source/Refitting/include/FPCCDSiliconTracking_MarlinTrk.h
+++ b/source/Refitting/include/FPCCDSiliconTracking_MarlinTrk.h
@@ -224,6 +224,8 @@ public:
   
   
   FPCCDSiliconTracking_MarlinTrk() ;
+  FPCCDSiliconTracking_MarlinTrk(const FPCCDSiliconTracking_MarlinTrk&) = delete ;
+  FPCCDSiliconTracking_MarlinTrk& operator=(const FPCCDSiliconTracking_MarlinTrk&) = delete ;
   
   /**  
    * Initialization
@@ -249,46 +251,46 @@ public:
   
 protected:
   
-  int _nRun ;
-  int _nEvt ;
-  EVENT::LCEvent* _current_event;
+  int _nRun {};
+  int _nEvt {};
+  EVENT::LCEvent* _current_event{nullptr};
   
-  int _nDivisionsInPhi;
-  int _nDivisionsInTheta;
-  int _nLayers;
+  int _nDivisionsInPhi{};
+  int _nDivisionsInTheta{};
+  int _nLayers{};
   
-  MarlinTrk::HelixFit* _fastfitter;
+  MarlinTrk::HelixFit* _fastfitter{nullptr};
   
   /** pointer to the IMarlinTrkSystem instance 
    */
-  MarlinTrk::IMarlinTrkSystem* _trksystem ;
-  bool _runMarlinTrkDiagnostics;
-  std::string _MarlinTrkDiagnosticsName;
+  MarlinTrk::IMarlinTrkSystem* _trksystem {nullptr};
+  bool _runMarlinTrkDiagnostics{};
+  std::string _MarlinTrkDiagnosticsName{};
   
-  bool _MSOn, _ElossOn, _SmoothOn ;
+  bool _MSOn{}, _ElossOn{}, _SmoothOn{};
   
-  float _initialTrackError_d0;
-  float _initialTrackError_phi0;
-  float _initialTrackError_omega;
-  float _initialTrackError_z0;
-  float _initialTrackError_tanL;
+  float _initialTrackError_d0{};
+  float _initialTrackError_phi0{};
+  float _initialTrackError_omega{};
+  float _initialTrackError_z0{};
+  float _initialTrackError_tanL{};
   
-  double _maxChi2PerHit;  
-  double _maxChi2PerHit2nd;  
+  double _maxChi2PerHit{};
+  double _maxChi2PerHit2nd{};
   
-  bool  _UseEventDisplay;
-  std::vector<int> _colours;  
+  bool  _UseEventDisplay{};
+  std::vector<int> _colours{};
   
   void drawEvent();
   
   
   // histogram member variables
   
-  bool  _createDiagnosticsHistograms;
-  DiagnosticsHistograms::Histograms* _histos ;
+  bool  _createDiagnosticsHistograms{};
+  DiagnosticsHistograms::Histograms* _histos {nullptr};
 
   
-  int _ntriplets, _ntriplets_good, _ntriplets_2MCP, _ntriplets_3MCP, _ntriplets_1MCP_Bad, _ntriplets_bad;
+  int _ntriplets{}, _ntriplets_good{}, _ntriplets_2MCP{}, _ntriplets_3MCP{}, _ntriplets_1MCP_Bad{}, _ntriplets_bad{};
   
   
   /** helper function to get collection using try catch block */
@@ -298,7 +300,7 @@ protected:
   LCRelationNavigator* GetRelations( LCEvent * evt, std::string RelName ) ;
   
   /** input MCParticle collection and threshold used for Drawing */
-  std::string  _colNameMCParticles;
+  std::string  _colNameMCParticles{};
   
   
   /// Compare tracks according to their chi2/ndf
@@ -311,17 +313,17 @@ protected:
   };
   
   
-  std::string _VTXHitCollection;
-  std::string _FTDPixelHitCollection;
-  std::string _FTDSpacePointCollection;
-  std::string _SITHitCollection;
-  std::string _siTrkCollection;
+  std::string _VTXHitCollection{};
+  std::string _FTDPixelHitCollection{};
+  std::string _FTDSpacePointCollection{};
+  std::string _SITHitCollection{};
+  std::string _siTrkCollection{};
   
-  std::vector< LCCollection* > _colTrackerHits;
-  std::map< LCCollection*, std::string > _colNamesTrackerHits;
+  std::vector< LCCollection* > _colTrackerHits{};
+  std::map< LCCollection*, std::string > _colNamesTrackerHits{};
   
-  std::vector<TrackerHitExtendedVec> _sectors;
-  std::vector<TrackerHitExtendedVec> _sectorsFTD;
+  std::vector<TrackerHitExtendedVec> _sectors{};
+  std::vector<TrackerHitExtendedVec> _sectorsFTD{};
   
   /**
    * A helper class to allow good code readability by accessing tracks with N hits.
@@ -354,11 +356,11 @@ protected:
     }
     
   protected:
-    std::vector< TrackExtendedVec > _tracksNHits;
-    size_t _maxIndex; /// local cache variable to avoid calculation overhead
+    std::vector< TrackExtendedVec > _tracksNHits{};
+    size_t _maxIndex{}; /// local cache variable to avoid calculation overhead
   };
   
-  TracksWithNHitsContainer _tracksWithNHitsContainer;
+  TracksWithNHitsContainer _tracksWithNHitsContainer{};
   
   int InitialiseVTX(LCEvent * evt);
   int InitialiseFTD(LCEvent * evt);
@@ -378,9 +380,9 @@ protected:
                  int innerlayer,
                  TrackExtended * trackAR);
 
-  int _useBuildTrackForHighPt;
-  double _cosThetaRangeForBuildTrackForHighPt;
-  double _phiRangeForBuildTrackForHighPt;
+  int _useBuildTrackForHighPt{};
+  double _cosThetaRangeForBuildTrackForHighPt{};
+  double _phiRangeForBuildTrackForHighPt{};
   void getPhiThetaRegionForHighPt(int* boundaries,TrackExtended* trackAR);
 
   void Sorting( TrackExtendedVec & trackVec);
@@ -397,76 +399,76 @@ protected:
   
   void FinalRefit(LCCollectionVec* trk_col, LCCollectionVec* rel_col);
   
-  float _bField;
-  float _chi2WRPhiTriplet;
-  float _chi2WRPhiQuartet;
-  float _chi2WRPhiSeptet;
-  float _chi2WZTriplet;
-  float _chi2WZQuartet;
-  float _chi2WZSeptet;
-  float _minDistCutAttachForFTD;
-  float _minDistCutAttachForVXD;
-  int _minimalLayerToAttach;
-  int _minMissAddition;
+  float _bField{};
+  float _chi2WRPhiTriplet{};
+  float _chi2WRPhiQuartet{};
+  float _chi2WRPhiSeptet{};
+  float _chi2WZTriplet{};
+  float _chi2WZQuartet{};
+  float _chi2WZSeptet{};
+  float _minDistCutAttachForFTD{};
+  float _minDistCutAttachForVXD{};
+  int _minimalLayerToAttach{};
+  int _minMissAddition{};
   
   // two pi is not a constant in cmath. Calculate it, once!
   static const double TWOPI;
   
-  double _dPhi;
-  double _dTheta;
-  double _dPhiFTD;
+  double _dPhi{};
+  double _dTheta{};
+  double _dPhiFTD{};
   
 
   
-  std::vector<int> _Combinations;
-  std::vector<int> _CombinationsFTD;
+  std::vector<int> _Combinations{};
+  std::vector<int> _CombinationsFTD{};
   
-  float _resolutionRPhiVTX;
-  float _resolutionZVTX;
+  float _resolutionRPhiVTX{};
+  float _resolutionZVTX{};
   
-  float _resolutionRPhiFTD;
-  float _resolutionZFTD;
+  float _resolutionRPhiFTD{};
+  float _resolutionZFTD{};
   
-  float _resolutionRPhiSIT;
-  float _resolutionZSIT;
+  float _resolutionRPhiSIT{};
+  float _resolutionZSIT{};
   
-  float _phiCutForMerging;
-  float _tanlambdaCutForMerging;
-  float _angleCutForMerging;
+  float _phiCutForMerging{};
+  float _tanlambdaCutForMerging{};
+  float _angleCutForMerging{};
   //float _angleCutForMerging_highPt;
   //float _angleCutForMerging_lowPt;
   
-  int _print;
-  int _checkForDelta;
-  float _minDistToDelta;
+  int _print{};
+  int _checkForDelta{};
+  float _minDistToDelta{};
   
-  float _distRPhi;
-  float _distZ;
-  float _chi2FitCut;
-  float _chi2FitCut_lowPt;
-  
-  
-  TrackExtendedVec _trackImplVec;
+  float _distRPhi{};
+  float _distZ{};
+  float _chi2FitCut{};
+  float _chi2FitCut_lowPt{};
   
   
-  float _cutOnD0, _cutOnZ0, _cutOnOmegaVXD, _cutOnOmegaFTD;
-  double _cutOnPtVXD,_cutOnPtFTD;
+  TrackExtendedVec _trackImplVec{};
   
-  int _minimalHits;
-  int _nHitsChi2;
-  int _attachVXD;
-  int _attachFTD;
   
-  int _max_hits_per_sector;
+  float _cutOnD0{}, _cutOnZ0{}, _cutOnOmegaVXD{}, _cutOnOmegaFTD{};
+  double _cutOnPtVXD{},_cutOnPtFTD{};
   
-  int _nTotalVTXHits,_nTotalFTDHits,_nTotalSITHits;
-  int _useSIT;
-  int _useFTD;
+  int _minimalHits{};
+  int _nHitsChi2{};
+  int _attachVXD{};
+  int _attachFTD{};
+  
+  int _max_hits_per_sector{};
+  
+  int _nTotalVTXHits{},_nTotalFTDHits{},_nTotalSITHits{};
+  int _useSIT{};
+  int _useFTD{};
   
   
   //  int _createMap;
   
-  UTIL::BitField64* _encoder;
+  UTIL::BitField64* _encoder{nullptr};
   int getDetectorID(TrackerHit* hit) { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::subdet()]; }
   int getSideID(TrackerHit* hit)     { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::side()]; };
   int getLayerID(TrackerHit* hit)    { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::layer()]; };
@@ -482,26 +484,26 @@ protected:
   void setupGeom(const dd4hep::Detector& theDetector) ;
   
   
-  unsigned int _nLayersVTX;
+  unsigned int _nLayersVTX{};
   
-  unsigned int _nLayersSIT;
+  unsigned int _nLayersSIT{};
   
   
-  std::vector<float> _zLayerFTD;
+  std::vector<float> _zLayerFTD{};
   
-  unsigned int _nlayersFTD;
-  bool _petalBasedFTDWithOverlaps;
-  int _nPhiFTD; 
+  unsigned int _nlayersFTD{};
+  bool _petalBasedFTDWithOverlaps{};
+  int _nPhiFTD{};
 
-  int _output_track_col_quality;
+  int _output_track_col_quality{};
   static const int _output_track_col_quality_GOOD;
   static const int _output_track_col_quality_FAIR;
   static const int _output_track_col_quality_POOR;
 
-  int _sw_theta;//search window theta
-  float _chi2FitCut_kalman;
-  bool _useClusterRejection;
-  float _minDotOf2Clusters;
+  int _sw_theta{};//search window theta
+  float _chi2FitCut_kalman{};
+  bool _useClusterRejection{};
+  float _minDotOf2Clusters{};
 
   int getIntersectionEasy(HelixClass_double& helix, TrackerHit* curInmos , int layer, double* isec, double* ref); 
   int getIntersectionEasyTest(HelixClass_double& helix, TrackerHit* basisTrkhit , int layer, std::vector<double> &vec ); 
@@ -511,50 +513,50 @@ protected:
   int getPhiThetaRegion(TrackExtended* trackAR, int layer, int* Boundaries);
 
   struct GeoData_t {
-    int nladder;
-    double rmin;  // distance of inner surface of sensitive region from IP
-    double dphi;  // azimuthal angle step of each ladder
-    double phi0;  // aximuthal angle offset
-    std::vector<double> cosphi;  // cos[phi_ladder], cos_phi of each ladder
-    std::vector<double> sinphi;  // sin[phi_ladder], sin_phi of each ladder
-    std::vector<double> phi;  // phi of each ladder
-    std::vector<double> phiAtXiMin;  // phiAtXiMin of each ladder
-    std::vector<double> phiAtXiMax;  // phiAtXiMax of each ladder
-    std::vector<double> ladder_incline;//the tilt of the line of the ladder expressed by phi
-    double sthick;  // sensitive region thickness
-    double sximin;  // minimum xi of sensitive region.
-    double sximax;  // maximum xi of sensitive region
-    double hlength; // ladder's half length in z
-    int num_xi_pixel;      // Number of xi pixel in this ladder
-    int num_zeta_pixel;    // Number of zeta pixel in this ladder
-    double rmes; //distance in R of measurement surface 
+    int nladder{};
+    double rmin{};  // distance of inner surface of sensitive region from IP
+    double dphi{};  // azimuthal angle step of each ladder
+    double phi0{};  // aximuthal angle offset
+    std::vector<double> cosphi{};  // cos[phi_ladder], cos_phi of each ladder
+    std::vector<double> sinphi{};  // sin[phi_ladder], sin_phi of each ladder
+    std::vector<double> phi{};  // phi of each ladder
+    std::vector<double> phiAtXiMin{};  // phiAtXiMin of each ladder
+    std::vector<double> phiAtXiMax{};  // phiAtXiMax of each ladder
+    std::vector<double> ladder_incline{};//the tilt of the line of the ladder expressed by phi
+    double sthick{};  // sensitive region thickness
+    double sximin{};  // minimum xi of sensitive region.
+    double sximax{};  // maximum xi of sensitive region
+    double hlength{}; // ladder's half length in z
+    int num_xi_pixel{};      // Number of xi pixel in this ladder
+    int num_zeta_pixel{};    // Number of zeta pixel in this ladder
+    double rmes{}; //distance in R of measurement surface
   };
   
   struct vxdGeoData_t {
-     int nLayer;
-     int maxLadder;
-     std::vector<GeoData_t> geodata;
-  }_vxd,_sit;
+  int nLayer{};
+  int maxLadder{};
+  std::vector<GeoData_t> geodata{};
+  }_vxd{},_sit{};
 
   void InitVXDGeometry(const dd4hep::Detector& theDetector);
   void InitSITGeometry(const dd4hep::Detector& theDetector);
-  FloatVec _pixelSizeVec;
-  float _pixelheight;
+  FloatVec _pixelSizeVec{};
+  float _pixelheight{};
   TVector3 LocalToGlobal(TVector3 local,int layer,int ladder);
   //purityMCP CheckOriginOf2Clusters(TrackerHit* A, TrackerHit* B);
   void calcTrackParameterOfMCP(MCParticle* pmcp, double* par);
   
   class ClusterStatus{
     public :
-     int cellid0 ;
-     int cellid1;
-     unsigned int layer ;
-     unsigned int ladder;
-     unsigned int   xiwidth ;
-     unsigned int zetawidth ;
-     unsigned int      nPix ;
-     unsigned int      tilt ;
-     unsigned int   quality ;
+    int cellid0 {};
+    int cellid1{};
+    unsigned int layer {};
+    unsigned int ladder{};
+    unsigned int   xiwidth {};
+    unsigned int zetawidth {};
+    unsigned int      nPix {};
+    unsigned int      tilt {};
+    unsigned int   quality {};
 
      ClusterStatus(TrackerHit* hit){
         cellid0 = hit->getCellID0(); 
@@ -577,89 +579,89 @@ protected:
 
   //Old Ver//////////////////
   typedef std::map< std::pair< int, int >, int > RangeMap;
-  RangeMap _phiRangeForTriplet;
+  RangeMap _phiRangeForTriplet{};
 
   double getNeededPhiSectors(double Pt, int outly , int inly); //Difference of radian is returned
   ///////////////////////////
 
   //New Ver////////////////////==under construction====
   typedef std::map< std::vector<int> , std::vector<int> > RangeMapVer2;
-  RangeMapVer2 _phiRangeForTripletVer2;
+  RangeMapVer2 _phiRangeForTripletVer2{};
   void getNeededPhiSectorsVer2(double Pt, std::vector<int> layers, std::vector<double>& phiDiff);
   /////////////////////////////========================
 
-  float _safetyPhiRange_ratio;/**
+  float _safetyPhiRange_ratio{};/**
   Extra range in addition to main range used for triplet construction process and needed to find triplet 
   is calculated by getNeededPhiSectors, but safety range is not considered.
   Value of _safetyRange is used such as Range = Range*(1 + _safetyRange);
   */
-  int _safetyPhiRange_fix;
-  float _fudgeFactorForSITsr_rphi;
-  float _fudgeFactorForSITsr_z;
-  int _fudgePhiRange;
-  int _fudgeThetaRange;
+  int _safetyPhiRange_fix{};
+  float _fudgeFactorForSITsr_rphi{};
+  float _fudgeFactorForSITsr_z{};
+  int _fudgePhiRange{};
+  int _fudgeThetaRange{};
 
-  std::string _colNameVXDTrackerHitRelations;
-  std::string _colNameSITSpacePointRelations;
-  std::string _colNameFTDSpacePointRelations;
-  std::string _colNameFTDPixelTrackerHitRelations;
-  LCRelationNavigator* _navVXD;
-  LCRelationNavigator* _navSIT;
-  LCRelationNavigator* _navFTDsp;
-  LCRelationNavigator* _navFTDpix;
-  std::string _colNameVXDSimHit;
-  std::string _colNameSITSimHit;
-  std::string _colNameFTDspSimHit;
-  std::string _colNameFTDpixSimHit;
-  LCCollection* _simVXD;
-  LCCollection* _simSIT;
-  LCCollection* _simFTDsp;
-  LCCollection* _simFTDpix;
+  std::string _colNameVXDTrackerHitRelations{};
+  std::string _colNameSITSpacePointRelations{};
+  std::string _colNameFTDSpacePointRelations{};
+  std::string _colNameFTDPixelTrackerHitRelations{};
+  LCRelationNavigator* _navVXD{nullptr};
+  LCRelationNavigator* _navSIT{nullptr};
+  LCRelationNavigator* _navFTDsp{nullptr};
+  LCRelationNavigator* _navFTDpix{nullptr};
+  std::string _colNameVXDSimHit{};
+  std::string _colNameSITSimHit{};
+  std::string _colNameFTDspSimHit{};
+  std::string _colNameFTDpixSimHit{};
+  LCCollection* _simVXD{nullptr};
+  LCCollection* _simSIT{nullptr};
+  LCCollection* _simFTDsp{nullptr};
+  LCCollection* _simFTDpix{nullptr};
 
 
 
-  double _nSigmaBuild_phi;
-  double _nSigmaBuild_theta;
+  double _nSigmaBuild_phi{};
+  double _nSigmaBuild_theta{};
 
-  bool _keepCandidate;//used in AttachRemainingVTXHitsVeryFast <-- under construction for now
+  bool _keepCandidate{};//used in AttachRemainingVTXHitsVeryFast <-- under construction for now
 
-  moriUTIL* _moriUtil;
-  GetPurityUtil* _purityUtil;
+  moriUTIL* _moriUtil{nullptr};
+  GetPurityUtil* _purityUtil{nullptr};
 
 ////////////////////////////////////////////////////////////////
 ////from here, a lot of debug tools and variables for mori /////
 ////////////////////////////////////////////////////////////////
-  bool _mydebug;
-  bool _mydebugKalFit;
-  bool _mydebugIntersection;
-  bool _mydebugRoot;
-  bool _mydebugRootVXD;
-  bool _mydebugRootFTD;
-  bool _mydebugRootVXDFTD;
-  bool _mydebugVXDHits;
-  bool _mydebugSITHits;
-  bool _mydebugTriplet;
-  int  _mydebugTripletMode;
-  bool _mydebugTripletVXD;
-  bool _mydebugTripletFTD;
-  bool _mydebugTripletVXDFTD;
-  bool _mydebugBuildTrack;
-  int  _mydebugBuildTrackMode;
-  bool _mydebugAttachVXD;
-  bool _mydebugPrintMCP;
-  bool _stopwatch;
+  bool _mydebug{};
+  bool _mydebugKalFit{};
+  bool _mydebugIntersection{};
+  bool _mydebugRoot{};
+  bool _mydebugRootVXD{};
+  bool _mydebugRootFTD{};
+  bool _mydebugRootVXDFTD{};
+  bool _mydebugVXDHits{};
+  bool _mydebugSITHits{};
+  bool _mydebugTriplet{};
+  int  _mydebugTripletMode{};
+  bool _mydebugTripletVXD{};
+  bool _mydebugTripletFTD{};
+  bool _mydebugTripletVXDFTD{};
+  bool _mydebugBuildTrack{};
+  int  _mydebugBuildTrackMode{};
+  bool _mydebugAttachVXD{};
+  bool _mydebugPrintMCP{};
+  bool _stopwatch{};
   class Timer{
    public:
-    TStopwatch inAnEvt;
-    TStopwatch InitialiseVTX;
-    TStopwatch InitialiseFTD;
-    TStopwatch ProcessOneSector;
-    TStopwatch TrackingInFTD;
-    TStopwatch Sorting;
-    TStopwatch CreateTrack;
-    TStopwatch AttachRemainingVXD;
-    TStopwatch AttachRemainingFTD;
-    TStopwatch FinalRefit;
+    TStopwatch inAnEvt{};
+    TStopwatch InitialiseVTX{};
+    TStopwatch InitialiseFTD{};
+    TStopwatch ProcessOneSector{};
+    TStopwatch TrackingInFTD{};
+    TStopwatch Sorting{};
+    TStopwatch CreateTrack{};
+    TStopwatch AttachRemainingVXD{};
+    TStopwatch AttachRemainingFTD{};
+    TStopwatch FinalRefit{};
     void reset(){
       inAnEvt.Reset();
       InitialiseVTX.Reset();
@@ -685,20 +687,20 @@ protected:
       printf("FinalRefit        : RT=%.3f s, CPU=%.3f s \n",FinalRefit.RealTime(),FinalRefit.CpuTime());
     }
     Timer(){reset();}
-  }_timer;
-  TStopwatch _timer2Triplet;
-  TStopwatch _timer2Build;
-  bool  _mydebugstopwatch2;
+  }_timer{};
+  TStopwatch _timer2Triplet{};
+  TStopwatch _timer2Build{};
+  bool  _mydebugstopwatch2{};
 
-  float _currentPurity;
+  float _currentPurity{};
   MCPMap LoadMCPMap();
-  std::map< MCParticle*, SimTrackerHitVec > _mcpVXD;
-  std::map< MCParticle*, SimTrackerHitVec > _mcpVXDFTD;
-  std::map< MCParticle*, SimTrackerHitVec > _mcpVXDSIT;
-  std::map< MCParticle*, SimTrackerHitVec > _mcpVXDFTDSIT;
-  std::map< MCParticle*, SimTrackerHitVec > _mcpFTD;
-  std::map< MCParticle*, SimTrackerHitVec > _mcpFTDSIT;
-  std::map< MCParticle*, SimTrackerHitVec > _mcpSIT;
+  std::map< MCParticle*, SimTrackerHitVec > _mcpVXD{};
+  std::map< MCParticle*, SimTrackerHitVec > _mcpVXDFTD{};
+  std::map< MCParticle*, SimTrackerHitVec > _mcpVXDSIT{};
+  std::map< MCParticle*, SimTrackerHitVec > _mcpVXDFTDSIT{};
+  std::map< MCParticle*, SimTrackerHitVec > _mcpFTD{};
+  std::map< MCParticle*, SimTrackerHitVec > _mcpFTDSIT{};
+  std::map< MCParticle*, SimTrackerHitVec > _mcpSIT{};
 
 
   enum MCPContributions{
@@ -718,26 +720,26 @@ protected:
   class Triplet : public IMPL::TrackImpl{
    public :
      static int numOfProcesses;
-     int id;
-     int quality_code;
-     int detID[3];//内側に近いところから詰める。
-     int layer[3];
-     float probability;
-     float purity;
-     SimTrackerHitVec simVecFromTrk;//TrackerHitVecに対応するもの
-     std::pair< MCParticle* , SimTrackerHitVec > mcTruth ;//Dominant MCPについての情報
+     int id{};
+     int quality_code{};
+     int detID[3]{};//内側に近いところから詰める。
+     int layer[3]{};
+     float probability{};
+     float purity{};
+     SimTrackerHitVec simVecFromTrk{};//TrackerHitVecに対応するもの
+     std::pair< MCParticle* , SimTrackerHitVec > mcTruth {};//Dominant MCPについての情報
 
      //new (2013_08_10)
-     TrackerHitVec truthTrkHits ;//Dominant MCPのsimthitsに対応するTrackerHitVec.
-     enum MCPContributions mcpcont;
-     IntVec nsub;//vxd:0,sit:1,ftd:2 <--for Dominant MCP
+     TrackerHitVec truthTrkHits {};//Dominant MCPのsimthitsに対応するTrackerHitVec.
+     enum MCPContributions mcpcont{};
+     IntVec nsub{};//vxd:0,sit:1,ftd:2 <--for Dominant MCP
      
 
-     float mcp_d0;
-     float mcp_z0;
-     float mcp_omega;
-     float mcp_phi0;
-     float mcp_tanL;
+     float mcp_d0{};
+     float mcp_z0{};
+     float mcp_omega{};
+     float mcp_phi0{};
+     float mcp_tanL{};
 
      //bool availableInBuildedTrack;
 
@@ -758,11 +760,9 @@ protected:
        nsub.clear();
        mcp_d0 = mcp_z0 = mcp_omega = mcp_phi0 = mcp_tanL = 1e20;
      }
-     Triplet(const Triplet& obj) : IMPL::TrackImpl(obj){
-       *this = obj;
-     }
+     Triplet(const Triplet&) = default;
   };
-  Triplet* _curtriplet;
+  Triplet* _curtriplet{nullptr};
   
 
   enum BuildTrackResult{
@@ -775,16 +775,16 @@ protected:
   class BuildedTrack : public IMPL::TrackImpl{
    public :
      static int numOfProcesses;
-     int id;
+     int id{};
 
-     BuildTrackResult result;
-     int nMisAssign;
-     Triplet triplet;
-     const MCParticle* truthmcp;
-     SimTrackerHitVec simvec;
-     float probability;
-     float purity;
-     SimTrackerHitVec simVecFromTrk;//TrackerHitVecに対応するもの
+     BuildTrackResult result{};
+     int nMisAssign{};
+     Triplet triplet{};
+     const MCParticle* truthmcp{nullptr};
+     SimTrackerHitVec simvec{};
+     float probability{};
+     float purity{};
+     SimTrackerHitVec simVecFromTrk{};//TrackerHitVecに対応するもの
      BuildedTrack():triplet(false){
         id = numOfProcesses; 
         numOfProcesses++;
@@ -796,14 +796,13 @@ protected:
         purity = 1e20;
         simVecFromTrk.clear();
      }
-     BuildedTrack(const BuildedTrack& obj) : IMPL::TrackImpl(obj){
-       *this = obj;
-     }
+     BuildedTrack(const BuildedTrack&) = default;
+     BuildedTrack& operator=(const BuildedTrack&) = default;
   };
-  bool _availableInBuildedTrack;
+  bool _availableInBuildedTrack{};
 
   typedef std::vector< BuildedTrack > BuildedTrackVec;
-  BuildedTrackVec _buildedTrackContainer;
+  BuildedTrackVec _buildedTrackContainer{};
   void SetBuildedTrack(TrackExtended* trackAR, BuildedTrackVec& btrackvec);
   void BuildedTrackDebuger1(BuildedTrackVec::iterator begin, BuildedTrackVec::iterator end);
   void BuildedTrackDebuger2(std::vector<const BuildedTrack*>::iterator begin, std::vector<const BuildedTrack*>::iterator end);
@@ -811,46 +810,46 @@ protected:
   //時間がアレばclass templateにしてみたい。
   class MCP_BuildedTrack{
    public :
-     std::pair<MCParticle*,SimTrackerHitVec> pair;
-     IntVec nsub;//nhits in sub detectors. 0 VXD, 1 FTD, 2 SIT
-     std::vector<const BuildedTrack*> BuildedTrackVec;
-     std::vector<const BuildedTrack*> BuildedTrack2ndVec;
-     std::vector<const BuildedTrack*> BuildedTrack3rdVec;
+    std::pair<MCParticle*,SimTrackerHitVec> pair{};
+    IntVec nsub{};//nhits in sub detectors. 0 VXD, 1 FTD, 2 SIT
+    std::vector<const BuildedTrack*> BuildedTrackVec{};
+    std::vector<const BuildedTrack*> BuildedTrack2ndVec{};
+    std::vector<const BuildedTrack*> BuildedTrack3rdVec{};
   };
   typedef std::map<MCParticle*,MCP_BuildedTrack> BTMap; 
-  BTMap _mcpBuildedTrackContainer;
+  BTMap _mcpBuildedTrackContainer{};
 
-  std::vector< std::map<MCParticle*, MCP_BuildedTrack> > _mcpRemainingBTContainerA;
+  std::vector< std::map<MCParticle*, MCP_BuildedTrack> > _mcpRemainingBTContainerA{};
   //purity 100%のトリプレットが生成されなかった生成されなかったmcp
-  std::vector< std::map<MCParticle*, MCP_BuildedTrack> > _mcpRemainingBTContainerB;
+  std::vector< std::map<MCParticle*, MCP_BuildedTrack> > _mcpRemainingBTContainerB{};
   //purity 100%のトリプレットが生成されたものの、quality_code != 0により結局再構成されなかったmcp
   
 
 
 
-  std::vector< Triplet > _tripletContainer;
+  std::vector< Triplet > _tripletContainer{};
 
   class MCP_Triplet{
    public :
-     std::pair<MCParticle*,SimTrackerHitVec> pair;
-     IntVec nsub;//nhits in sub detectors. 0 VXD, 1 FTD, 2 SIT
-     std::vector<const Triplet*> tripvec;
-     std::vector<const Triplet*> trip2ndvec;
-     std::vector<const Triplet*> trip3rdvec;
+    std::pair<MCParticle*,SimTrackerHitVec> pair{};
+    IntVec nsub{};//nhits in sub detectors. 0 VXD, 1 FTD, 2 SIT
+    std::vector<const Triplet*> tripvec{};
+    std::vector<const Triplet*> trip2ndvec{};
+    std::vector<const Triplet*> trip3rdvec{};
   };
   typedef std::map<MCParticle*,MCP_Triplet> TripMap; 
-  TripMap _mcpTripletContainer;
+  TripMap _mcpTripletContainer{};
 
 
-  std::vector< std::map<MCParticle*, MCP_Triplet> > _mcpRemainingTRContainerA;
+  std::vector< std::map<MCParticle*, MCP_Triplet> > _mcpRemainingTRContainerA{};
   //purity 100%のトリプレットが生成されなかった生成されなかったmcp
-  std::vector< std::map<MCParticle*, MCP_Triplet> > _mcpRemainingTRContainerB;
+  std::vector< std::map<MCParticle*, MCP_Triplet> > _mcpRemainingTRContainerB{};
   //purity 100%のトリプレットが生成されたものの、quality_code != 0により結局再構成されなかったmcp
   
   void TripletDebugerWithMCPRemain(int nth, std::vector< std::map<MCParticle*, MCP_Triplet> > A);
 
-  MCPMap _mcpMap;
-  std::vector<LCRelationNavigator*> _naviVec;
+  MCPMap _mcpMap{};
+  std::vector<LCRelationNavigator*> _naviVec{};
   IntVec getNHitsInSubDet(SimTrackerHitVec simvec);
   void TripletDebuger1(std::vector<Triplet>::iterator begin, std::vector<Triplet>::iterator end);
   void TripletDebuger2(std::vector<const Triplet*>::iterator begin, std::vector<const Triplet*>::iterator end);

--- a/source/Refitting/include/FullLDCTracking_MarlinTrk.h
+++ b/source/Refitting/include/FullLDCTracking_MarlinTrk.h
@@ -255,15 +255,16 @@ namespace dd4hep{
 class FullLDCTracking_MarlinTrk : public Processor {
   
 public:
-  
-  virtual Processor*  newProcessor() { return new FullLDCTracking_MarlinTrk ; }  
-  FullLDCTracking_MarlinTrk() ;  
-  virtual void init() ;
-  virtual void processRunHeader( LCRunHeader* run ) ;
-  virtual void processEvent( LCEvent * evt ) ; 
-  virtual void check( LCEvent * evt ) ; 
-  virtual void end() ;
-  
+  virtual Processor* newProcessor() { return new FullLDCTracking_MarlinTrk; }
+  FullLDCTracking_MarlinTrk();
+  FullLDCTracking_MarlinTrk(const FullLDCTracking_MarlinTrk&) = delete;
+  FullLDCTracking_MarlinTrk& operator=(const FullLDCTracking_MarlinTrk&) = delete;
+  virtual void init();
+  virtual void processRunHeader(LCRunHeader* run);
+  virtual void processEvent(LCEvent* evt);
+  virtual void check(LCEvent* evt);
+  virtual void end();
+
 protected:
   
   void prepareVectors( LCEvent * evt );
@@ -314,175 +315,185 @@ protected:
   
   int SegmentRadialOverlap(TrackExtended* pTracki, TrackExtended* pTrackj);
   bool VetoMerge(TrackExtended* firstTrackExt, TrackExtended* secondTrackExt);
-   
-  int _nRun ;
-  int _nEvt ;
-  
-  MarlinTrk::HelixFit* _fastfitter;
-  
-  /** pointer to the IMarlinTrkSystem instance 
-   */
-  MarlinTrk::IMarlinTrkSystem* _trksystem ;
-  std::string _trkSystemName ;
-  
-  bool _MSOn, _ElossOn, _SmoothOn ;
-  
-  std::string _TPCTrackCollection;
-  std::string _SiTrackCollection;
-  std::string _TPCTrackMCPCollName;
-  std::string _SiTrackMCPCollName;
-  
-  std::string _VTXTrackerHitCollection;
-  std::string _SITTrackerHitCollection;
-  std::string _SETTrackerHitCollection;
-  std::string _FTDPixelHitCollection;
-  std::string _FTDSpacePointCollection;
-  std::string _TPCTrackerHitCollection;
-  std::string _ETDTrackerHitCollection;
-  
-  std::string _LDCTrackCollection;
-  
-  
-  TrackExtendedVec _allSiTracks;
-  TrackExtendedVec _allTPCTracks;
-  TrackExtendedVec _allCombinedTracks;
-  TrackExtendedVec _allNonCombinedTPCTracks;
-  TrackExtendedVec _allNonCombinedSiTracks;
-  TrackExtendedVec _trkImplVec;
-  TrackerHitExtendedVec _allTPCHits;
-  TrackerHitExtendedVec _allVTXHits;
-  TrackerHitExtendedVec _allFTDHits;
-  TrackerHitExtendedVec _allSITHits;
-  TrackerHitExtendedVec _allSETHits;
-  TrackerHitExtendedVec _allETDHits;
-  
-  float PI, PIOVER2, TWOPI;
-  
-  float _bField;
-  float _chi2PrefitCut;
-  float _chi2FitCut;
-  
-  int _debug;
-  
-  float _dPCutForMerging;
-  float _d0CutForMerging;
-  float _z0CutForMerging;
-  float _dOmegaForMerging;
-  float _angleForMerging;
-  
-  
-  int   _forceMerging;
-  float _dPCutForForcedMerging;
-  float _d0CutForForcedMerging;
-  float _z0CutForForcedMerging;
-  float _dOmegaForForcedMerging;
-  float _angleForForcedMerging;
-  
-  
-  int _mergeTPCSegments;
-  float _dPCutToMergeTPC;
-  float _PtCutToMergeTPC;
-  float _d0CutToMergeTPC;
-  float _z0CutToMergeTPC;
-  
-  float _cosThetaCutHighPtMerge;
-  float _cosThetaCutSoftHighPtMerge;
-  float _momDiffCutHighPtMerge;
-  float _momDiffCutSoftHighPtMerge;
-  float _hitDistanceCutHighPtMerge;
-  float _maxHitDistanceCutHighPtMerge;
-  float _maxFractionOfOutliersCutHighPtMerge;
-  
-  float _vetoMergeMomentumCut;
-  
-  float _initialTrackError_d0;
-  float _initialTrackError_phi0;
-  float _initialTrackError_omega;
-  float _initialTrackError_z0;
-  float _initialTrackError_tanL;
-  
-  double _maxChi2PerHit;
-  double _minChi2ProbForSiliconTracks;
-  float  _maxAllowedPercentageOfOutliersForTrackCombination;
-  int    _maxAllowedSiHitRejectionsForTrackCombination;
-  
-  bool _runMarlinTrkDiagnostics;
-  std::string _MarlinTrkDiagnosticsName;
-  
-  int _nHitsExtrapolation;
-  
-  int _cutOnTPCHits;
-  int _cutOnSiHits;
-  
-  
-  int _assignVTXHits,_assignFTDHits,_assignSITHits,_assignTPCHits;
-  
-  int _assignSETHits, _assignETDHits;
-  
-  float _distCutForVTXHits,_distCutForFTDHits,_distCutForSITHits,_distCutForTPCHits;
-  
-  float _distCutForSETHits, _distCutForETDHits;
-  
-  
-  float _d0TrkCut,_z0TrkCut;
-  
-  int _forbidOverlapInZTPC,_forbidOverlapInZComb;
 
-  float _energyLossErrorTPC;
-  
-  LCEvent * _evt;
-  
-  std::map<TrackExtended*,HelixClass*> _trackExtrapolatedHelix;
-  std::set<TrackExtended*> _candidateCombinedTracks;
-  
-  UTIL::BitField64* _encoder;
-  int getDetectorID(TrackerHit* hit) { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::subdet()]; }
-  int getSideID(TrackerHit* hit)     { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::side()]; };
-  int getLayerID(TrackerHit* hit)    { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::layer()]; };
-  int getModuleID(TrackerHit* hit)   { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::module()]; };
-  int getSensorID(TrackerHit* hit)   { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::sensor()]; };
+  int _nRun{};
+  int _nEvt{};
+
+  MarlinTrk::HelixFit* _fastfitter{nullptr};
+
+  /** pointer to the IMarlinTrkSystem instance
+   */
+  MarlinTrk::IMarlinTrkSystem* _trksystem{nullptr};
+  std::string _trkSystemName{};
+
+  bool _MSOn{}, _ElossOn{}, _SmoothOn{};
+
+  std::string _TPCTrackCollection{};
+  std::string _SiTrackCollection{};
+  std::string _TPCTrackMCPCollName{};
+  std::string _SiTrackMCPCollName{};
+
+  std::string _VTXTrackerHitCollection{};
+  std::string _SITTrackerHitCollection{};
+  std::string _SETTrackerHitCollection{};
+  std::string _FTDPixelHitCollection{};
+  std::string _FTDSpacePointCollection{};
+  std::string _TPCTrackerHitCollection{};
+  std::string _ETDTrackerHitCollection{};
+
+  std::string _LDCTrackCollection{};
+
+  TrackExtendedVec _allSiTracks{};
+  TrackExtendedVec _allTPCTracks{};
+  TrackExtendedVec _allCombinedTracks{};
+  TrackExtendedVec _allNonCombinedTPCTracks{};
+  TrackExtendedVec _allNonCombinedSiTracks{};
+  TrackExtendedVec _trkImplVec{};
+  TrackerHitExtendedVec _allTPCHits{};
+  TrackerHitExtendedVec _allVTXHits{};
+  TrackerHitExtendedVec _allFTDHits{};
+  TrackerHitExtendedVec _allSITHits{};
+  TrackerHitExtendedVec _allSETHits{};
+  TrackerHitExtendedVec _allETDHits{};
+
+  float PI{}, PIOVER2{}, TWOPI{};
+
+  float _bField{};
+  float _chi2PrefitCut{};
+  float _chi2FitCut{};
+
+  int _debug{};
+
+  float _dPCutForMerging{};
+  float _d0CutForMerging{};
+  float _z0CutForMerging{};
+  float _dOmegaForMerging{};
+  float _angleForMerging{};
+
+  int _forceMerging{};
+  float _dPCutForForcedMerging{};
+  float _d0CutForForcedMerging{};
+  float _z0CutForForcedMerging{};
+  float _dOmegaForForcedMerging{};
+  float _angleForForcedMerging{};
+
+  int _mergeTPCSegments{};
+  float _dPCutToMergeTPC{};
+  float _PtCutToMergeTPC{};
+  float _d0CutToMergeTPC{};
+  float _z0CutToMergeTPC{};
+
+  float _cosThetaCutHighPtMerge{};
+  float _cosThetaCutSoftHighPtMerge{};
+  float _momDiffCutHighPtMerge{};
+  float _momDiffCutSoftHighPtMerge{};
+  float _hitDistanceCutHighPtMerge{};
+  float _maxHitDistanceCutHighPtMerge{};
+  float _maxFractionOfOutliersCutHighPtMerge{};
+
+  float _vetoMergeMomentumCut{};
+
+  float _initialTrackError_d0{};
+  float _initialTrackError_phi0{};
+  float _initialTrackError_omega{};
+  float _initialTrackError_z0{};
+  float _initialTrackError_tanL{};
+
+  double _maxChi2PerHit{};
+  double _minChi2ProbForSiliconTracks{};
+  float _maxAllowedPercentageOfOutliersForTrackCombination{};
+  int _maxAllowedSiHitRejectionsForTrackCombination{};
+
+  bool _runMarlinTrkDiagnostics{};
+  std::string _MarlinTrkDiagnosticsName{};
+
+  int _nHitsExtrapolation{};
+
+  int _cutOnTPCHits{};
+  int _cutOnSiHits{};
+
+  int _assignVTXHits{}, _assignFTDHits{}, _assignSITHits{}, _assignTPCHits{};
+
+  int _assignSETHits{}, _assignETDHits{};
+
+  float _distCutForVTXHits{}, _distCutForFTDHits{}, _distCutForSITHits{}, _distCutForTPCHits{};
+
+  float _distCutForSETHits{}, _distCutForETDHits{};
+
+  float _d0TrkCut{}, _z0TrkCut{};
+
+  int _forbidOverlapInZTPC{}, _forbidOverlapInZComb{};
+
+  float _energyLossErrorTPC{};
+
+  LCEvent* _evt{nullptr};
+
+  std::map<TrackExtended*, HelixClass*> _trackExtrapolatedHelix{};
+  std::set<TrackExtended*> _candidateCombinedTracks{};
+
+  UTIL::BitField64* _encoder{nullptr};
+  int getDetectorID(TrackerHit* hit) {
+    _encoder->setValue(hit->getCellID0());
+    return (*_encoder)[lcio::LCTrackerCellID::subdet()];
+  }
+  int getSideID(TrackerHit* hit) {
+    _encoder->setValue(hit->getCellID0());
+    return (*_encoder)[lcio::LCTrackerCellID::side()];
+  };
+  int getLayerID(TrackerHit* hit) {
+    _encoder->setValue(hit->getCellID0());
+    return (*_encoder)[lcio::LCTrackerCellID::layer()];
+  };
+  int getModuleID(TrackerHit* hit) {
+    _encoder->setValue(hit->getCellID0());
+    return (*_encoder)[lcio::LCTrackerCellID::module()];
+  };
+  int getSensorID(TrackerHit* hit) {
+    _encoder->setValue(hit->getCellID0());
+    return (*_encoder)[lcio::LCTrackerCellID::sensor()];
+  };
 
   
   void setupGeom(const dd4hep::Detector& lcdd) ;
 
-  double _tpc_inner_r;
-  double _tpc_outer_r;
-  double _tpc_pad_height;
-  int    _tpc_nrows;
-  
-//  struct VXD_Layer {
-//    int nLadders;
-//    double phi0;
-//    double dphi;
-//    double senRMin;
-//    double supRMin;
-//    double length;
-//    double width;
-//    double offset;
-//    double senThickness;
-//    double supThickness;
-//  };
-//  std::vector<VXD_Layer> _VXDgeo;
-  
-  unsigned int _nLayersVTX;
-  
-//  struct SIT_Layer {
-//    int nLadders;
-//    double phi0;
-//    double dphi;
-//    double senRMin;
-//    double supRMin;
-//    double length;
-//    double width;
-//    double offset;
-//    double senThickness;
-//    double supThickness;
-//  };
-//  std::vector<SIT_Layer> _SITgeo;
-  
-  unsigned int _nLayersSIT;
-  
-  unsigned int _nLayersSET;
+  double _tpc_inner_r{};
+  double _tpc_outer_r{};
+  double _tpc_pad_height{};
+  int _tpc_nrows{};
+
+  //  struct VXD_Layer {
+  //    int nLadders;
+  //    double phi0;
+  //    double dphi;
+  //    double senRMin;
+  //    double supRMin;
+  //    double length;
+  //    double width;
+  //    double offset;
+  //    double senThickness;
+  //    double supThickness;
+  //  };
+  //  std::vector<VXD_Layer> _VXDgeo;
+
+  unsigned int _nLayersVTX{};
+
+  //  struct SIT_Layer {
+  //    int nLadders;
+  //    double phi0;
+  //    double dphi;
+  //    double senRMin;
+  //    double supRMin;
+  //    double length;
+  //    double width;
+  //    double offset;
+  //    double senThickness;
+  //    double supThickness;
+  //  };
+  //  std::vector<SIT_Layer> _SITgeo;
+
+  unsigned int _nLayersSIT{};
+
+  unsigned int _nLayersSET{};
 
   
 //  struct FTD_Disk {
@@ -523,11 +534,11 @@ protected:
 //  };
 //  
 //  std::vector<FTD_Disk> _FTDgeo;
-  std::vector<float> _zLayerFTD;
+  std::vector<float> _zLayerFTD{};
   
-  unsigned int _nLayersFTD;
-  int _nPhiFTD; 
-  bool  _petalBasedFTDWithOverlaps;
+  unsigned int _nLayersFTD{};
+  int _nPhiFTD{};
+  bool  _petalBasedFTDWithOverlaps{};
   
 } ;
 

--- a/source/Refitting/include/RefitProcessor.h
+++ b/source/Refitting/include/RefitProcessor.h
@@ -41,6 +41,8 @@ public:
   virtual marlin::Processor*  newProcessor() { return new RefitProcessor ; }
   
   RefitProcessor() ;
+  RefitProcessor(const RefitProcessor&) = delete ;
+  RefitProcessor& operator=(const RefitProcessor&) = delete ;
   
   /** Called at the begin of the job before anything is read.
    * Use to initialize the processor, e.g. book histograms.
@@ -85,45 +87,45 @@ protected:
   
   /** Input track collection name for refitting.
    */
-  std::string _input_track_col_name ;
+  std::string _input_track_col_name {};
   
   /** Input track relations name for refitting.
    */
-  std::string _input_track_rel_name ;
+  std::string _input_track_rel_name {};
   
   /** refitted track collection name.
    */
-  std::string _output_track_col_name ;
+  std::string _output_track_col_name {};
   
   /** Output track relations name for refitting.
    */
-  std::string _output_track_rel_name ;
+  std::string _output_track_rel_name {};
   
   /** pointer to the IMarlinTrkSystem instance 
    */
-  MarlinTrk::IMarlinTrkSystem* _trksystem ;
+  MarlinTrk::IMarlinTrkSystem* _trksystem {nullptr};
   
-  bool _MSOn ;
-  bool _ElossOn ;
-  bool _SmoothOn ;
+  bool _MSOn {};
+  bool _ElossOn {};
+  bool _SmoothOn {};
   
-  float _initialTrackError_d0;
-  float _initialTrackError_phi0;
-  float _initialTrackError_omega;
-  float _initialTrackError_z0;
-  float _initialTrackError_tanL;
-  float _maxChi2PerHit;
-  double _mass ;
+  float _initialTrackError_d0{};
+  float _initialTrackError_phi0{};
+  float _initialTrackError_omega{};
+  float _initialTrackError_z0{};
+  float _initialTrackError_tanL{};
+  float _maxChi2PerHit{};
+  double _mass {};
 
-  int _n_run ;
-  int _n_evt ;
+  int _n_run {};
+  int _n_evt {};
 
-  int _initialTrackState;
-  int _fitDirection ; 
+  int _initialTrackState{};
+  int _fitDirection {};
 
-  std::string _trkSystemName ;
+  std::string _trkSystemName {};
   
-  float _bField;
+  float _bField{};
   
 } ;
 

--- a/source/Refitting/include/SiliconTracking_MarlinTrk.h
+++ b/source/Refitting/include/SiliconTracking_MarlinTrk.h
@@ -190,6 +190,8 @@ public:
   
   
   SiliconTracking_MarlinTrk() ;
+  SiliconTracking_MarlinTrk(const SiliconTracking_MarlinTrk&) = delete ;
+  SiliconTracking_MarlinTrk& operator=(const SiliconTracking_MarlinTrk&) = delete ;
   
   /**  
    * Initialization
@@ -215,53 +217,53 @@ public:
   
 protected:
   
-  int _nRun ;
-  int _nEvt ;
-  EVENT::LCEvent* _current_event;
+  int _nRun {};
+  int _nEvt {};
+  EVENT::LCEvent* _current_event{nullptr};
   
-  int _nDivisionsInPhi;
-  int _nDivisionsInTheta;
-  int _nLayers;
+  int _nDivisionsInPhi{};
+  int _nDivisionsInTheta{};
+  int _nLayers{};
   
-  MarlinTrk::HelixFit* _fastfitter;
+  MarlinTrk::HelixFit* _fastfitter{nullptr};
   
   /** pointer to the IMarlinTrkSystem instance 
    */
-  MarlinTrk::IMarlinTrkSystem* _trksystem ;
-  bool _runMarlinTrkDiagnostics;
-  std::string _MarlinTrkDiagnosticsName;
+  MarlinTrk::IMarlinTrkSystem* _trksystem {nullptr};
+  bool _runMarlinTrkDiagnostics{};
+  std::string _MarlinTrkDiagnosticsName{};
   
-  bool _MSOn, _ElossOn, _SmoothOn ;
+  bool _MSOn{}, _ElossOn{}, _SmoothOn {};
 
   /** switches: False for backward compatible (default).
                 True to apply new methods.
    */
-  bool _useSimpleUpdatedCoreBin;
-  bool _useSimpleAttachHitToTrack;
+  bool _useSimpleUpdatedCoreBin{};
+  bool _useSimpleAttachHitToTrack{};
 
-  float _initialTrackError_d0;
-  float _initialTrackError_phi0;
-  float _initialTrackError_omega;
-  float _initialTrackError_z0;
-  float _initialTrackError_tanL;
+  float _initialTrackError_d0{};
+  float _initialTrackError_phi0{};
+  float _initialTrackError_omega{};
+  float _initialTrackError_z0{};
+  float _initialTrackError_tanL{};
   
-  double _maxChi2PerHit;  
+  double _maxChi2PerHit{};  
   
-  bool  _UseEventDisplay;
-  int _detector_model_for_drawing;
-  std::vector<int> _colours;  
-  float     _helix_max_r;
+  bool  _UseEventDisplay{};
+  int _detector_model_for_drawing{};
+  std::vector<int> _colours{};  
+  float     _helix_max_r{};
   
   void drawEvent();
   
   
   // histogram member variables
   
-  bool  _createDiagnosticsHistograms;
+  bool  _createDiagnosticsHistograms{};
   DiagnosticsHistograms::Histograms* _histos{nullptr};
 
   
-  int _ntriplets, _ntriplets_good, _ntriplets_2MCP, _ntriplets_3MCP, _ntriplets_1MCP_Bad, _ntriplets_bad;
+  int _ntriplets{}, _ntriplets_good{}, _ntriplets_2MCP{}, _ntriplets_3MCP{}, _ntriplets_1MCP_Bad{}, _ntriplets_bad{};
   
   
   /** helper function to get collection using try catch block */
@@ -272,8 +274,8 @@ protected:
   
   /** input MCParticle collection and threshold used for Drawing
    */
-  std::string  _colNameMCParticles;
-  float _MCpThreshold ;
+  std::string  _colNameMCParticles{};
+  float _MCpThreshold {};
   
   
   /// Compare tracks according to their chi2/ndf
@@ -286,17 +288,17 @@ protected:
   };
   
   
-  std::string _VTXHitCollection;
-  std::string _FTDPixelHitCollection;
-  std::string _FTDSpacePointCollection;
-  std::string _SITHitCollection;
-  std::string _siTrkCollection;
+  std::string _VTXHitCollection{};
+  std::string _FTDPixelHitCollection{};
+  std::string _FTDSpacePointCollection{};
+  std::string _SITHitCollection{};
+  std::string _siTrkCollection{};
   
-  std::vector< LCCollection* > _colTrackerHits;
-  std::map< LCCollection*, std::string > _colNamesTrackerHits;
+  std::vector< LCCollection* > _colTrackerHits{};
+  std::map< LCCollection*, std::string > _colNamesTrackerHits{};
   
-  std::vector<TrackerHitExtendedVec> _sectors;
-  std::vector<TrackerHitExtendedVec> _sectorsFTD;
+  std::vector<TrackerHitExtendedVec> _sectors{};
+  std::vector<TrackerHitExtendedVec> _sectorsFTD{};
   
   /**
    * A helper class to allow good code readability by accessing tracks with N hits.
@@ -329,11 +331,11 @@ protected:
     }
     
   protected:
-    std::vector< TrackExtendedVec > _tracksNHits;
-    size_t _maxIndex; /// local cache variable to avoid calculation overhead
+    std::vector< TrackExtendedVec > _tracksNHits{};
+    size_t _maxIndex{}; /// local cache variable to avoid calculation overhead
   };
   
-  TracksWithNHitsContainer _tracksWithNHitsContainer;
+  TracksWithNHitsContainer _tracksWithNHitsContainer{};
   
   int InitialiseVTX(LCEvent * evt);
   int InitialiseFTD(LCEvent * evt);
@@ -365,69 +367,69 @@ protected:
   
   void FinalRefit(LCCollectionVec* trk_col, LCCollectionVec* rel_col);
   
-  float _bField;
-  float _chi2WRPhiTriplet;
-  float _chi2WRPhiQuartet;
-  float _chi2WRPhiSeptet;
-  float _chi2WZTriplet;
-  float _chi2WZQuartet;
-  float _chi2WZSeptet;
-  float _minDistCutAttach;
-  int _minimalLayerToAttach;
+  float _bField{};
+  float _chi2WRPhiTriplet{};
+  float _chi2WRPhiQuartet{};
+  float _chi2WRPhiSeptet{};
+  float _chi2WZTriplet{};
+  float _chi2WZQuartet{};
+  float _chi2WZSeptet{};
+  float _minDistCutAttach{};
+  int _minimalLayerToAttach{};
   
   // two pi is not a constant in cmath. Calculate it, once!
   static const double TWOPI;
   
-  double _dPhi;
-  double _dTheta;
-  double _dPhiFTD;
+  double _dPhi{};
+  double _dTheta{};
+  double _dPhiFTD{};
   
 
   
-  std::vector<int> _Combinations;
-  std::vector<int> _CombinationsFTD;
+  std::vector<int> _Combinations{};
+  std::vector<int> _CombinationsFTD{};
   
-  float _resolutionRPhiVTX;
-  float _resolutionZVTX;
+  float _resolutionRPhiVTX{};
+  float _resolutionZVTX{};
   
-  float _resolutionRPhiFTD;
-  float _resolutionZFTD;
+  float _resolutionRPhiFTD{};
+  float _resolutionZFTD{};
   
-  float _resolutionRPhiSIT;
-  float _resolutionZSIT;
+  float _resolutionRPhiSIT{};
+  float _resolutionZSIT{};
   
-  float _phiCutForMerging;
-  float _tanlambdaCutForMerging;
-  float _angleCutForMerging;
+  float _phiCutForMerging{};
+  float _tanlambdaCutForMerging{};
+  float _angleCutForMerging{};
   
-  int _print;
-  int _checkForDelta;
-  float _minDistToDelta;
+  int _print{};
+  int _checkForDelta{};
+  float _minDistToDelta{};
   
-  float _distRPhi;
-  float _distZ;
-  float _chi2FitCut;
-  
-  
-  TrackExtendedVec _trackImplVec;
+  float _distRPhi{};
+  float _distZ{};
+  float _chi2FitCut{};
   
   
-  float _cutOnD0, _cutOnZ0, _cutOnOmega, _cutOnPt;
+  TrackExtendedVec _trackImplVec{};
   
-  int _minimalHits;
-  int _nHitsChi2;
-  int _attachFast;
   
-  int _max_hits_per_sector;
+  float _cutOnD0{}, _cutOnZ0{}, _cutOnOmega{}, _cutOnPt{};
   
-  int _nTotalVTXHits,_nTotalFTDHits,_nTotalSITHits;
-  int _useSIT;
+  int _minimalHits{};
+  int _nHitsChi2{};
+  int _attachFast{};
+  
+  int _max_hits_per_sector{};
+  
+  int _nTotalVTXHits{},_nTotalFTDHits{},_nTotalSITHits{};
+  int _useSIT{};
 
-  std::string _trkSystemName ;
+  std::string _trkSystemName {};
   
   //  int _createMap;
   
-  UTIL::BitField64* _encoder;
+  UTIL::BitField64* _encoder{nullptr};
   int getDetectorID(TrackerHit* hit) { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::subdet()]; }
   int getSideID(TrackerHit* hit)     { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::side()]; };
   int getLayerID(TrackerHit* hit)    { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::layer()]; };
@@ -437,18 +439,18 @@ protected:
   void setupGeom(const dd4hep::Detector& theDetector);
   
   
-  unsigned int _nLayersVTX;
+  unsigned int _nLayersVTX{};
   
-  unsigned int _nLayersSIT;
+  unsigned int _nLayersSIT{};
   
   
-  std::vector<float> _zLayerFTD;
+  std::vector<float> _zLayerFTD{};
   
-  unsigned int _nlayersFTD;
-  bool _petalBasedFTDWithOverlaps;
-  int _nPhiFTD; 
+  unsigned int _nlayersFTD{};
+  bool _petalBasedFTDWithOverlaps{};
+  int _nPhiFTD{};
 
-  int _output_track_col_quality;
+  int _output_track_col_quality{};
   static const int _output_track_col_quality_GOOD;
   static const int _output_track_col_quality_FAIR;
   static const int _output_track_col_quality_POOR;

--- a/source/Refitting/include/TrackSubsetProcessor.h
+++ b/source/Refitting/include/TrackSubsetProcessor.h
@@ -57,6 +57,8 @@ class TrackSubsetProcessor : public Processor {
   
   
   TrackSubsetProcessor() ;
+  TrackSubsetProcessor(const TrackSubsetProcessor&) = delete ;
+  TrackSubsetProcessor& operator=(const TrackSubsetProcessor&) = delete ;
   
   /** Called at the begin of the job before anything is read.
    * Use to initialize the processor, e.g. book histograms.
@@ -89,34 +91,34 @@ class TrackSubsetProcessor : public Processor {
   
   
   /** Input collection names */
-  std::vector< std::string > _trackInputColNames;
+  std::vector< std::string > _trackInputColNames{};
   
   /** Output collection name */
-  std::string _trackOutputColName;
+  std::string _trackOutputColName{};
   
-  MarlinTrk::IMarlinTrkSystem* _trkSystem;
-  std::string _trkSystemName ;
+  MarlinTrk::IMarlinTrkSystem* _trkSystem{nullptr};
+  std::string _trkSystemName {};
   
-  bool _MSOn ;
-  bool _ElossOn ;
-  bool _SmoothOn ;
-  bool _removeShortTracks ;
+  bool _MSOn {};
+  bool _ElossOn {};
+  bool _SmoothOn {};
+  bool _removeShortTracks {};
 
 
-  float _initialTrackError_d0;
-  float _initialTrackError_phi0;
-  float _initialTrackError_omega;
-  float _initialTrackError_z0;
-  float _initialTrackError_tanL;
+  float _initialTrackError_d0{};
+  float _initialTrackError_phi0{};
+  float _initialTrackError_omega{};
+  float _initialTrackError_z0{};
+  float _initialTrackError_tanL{};
   
-  double _maxChi2PerHit;
+  double _maxChi2PerHit{};
   
-  float _bField;
+  float _bField{};
   
-  int _nRun ;
-  int _nEvt ;
+  int _nRun {};
+  int _nEvt {};
   
-  double _omega;
+  double _omega{};
   
 } ;
 
@@ -171,7 +173,7 @@ public:
   
 protected:
   
-  MarlinTrk::IMarlinTrkSystem* _trkSystem;
+  MarlinTrk::IMarlinTrkSystem* _trkSystem{nullptr};
     
 };
 

--- a/source/Refitting/include/TruthTrackFinder.h
+++ b/source/Refitting/include/TruthTrackFinder.h
@@ -29,6 +29,8 @@ class TruthTrackFinder : public Processor {
   virtual Processor*  newProcessor() { return new TruthTrackFinder ; }
 	
   TruthTrackFinder() ;
+  TruthTrackFinder(const TruthTrackFinder&) = delete ;
+  TruthTrackFinder& operator=(const TruthTrackFinder&) = delete ;
 	
   // Initialisation - run at the beginning to start histograms, etc.
   virtual void init() ;
@@ -52,7 +54,7 @@ class TruthTrackFinder : public Processor {
  protected:
 	
   // Encoder
-  UTIL::BitField64* m_encoder;
+  UTIL::BitField64* m_encoder{nullptr};
 
   // Get the subdetector ID from a hit
   int getSubdetector(const TrackerHit* hit){ m_encoder->setValue(hit->getCellID0()); return (*m_encoder)[lcio::LCTrackerCellID::subdet()]; } 
@@ -66,31 +68,31 @@ class TruthTrackFinder : public Processor {
 
 
   // Collection names for (in/out)put
-  std::vector<std::string> m_inputTrackerHitCollections ;
-  std::vector<std::string> m_inputTrackerHitRelationCollections ;
-  std::string m_inputParticleCollection ;
-  std::string m_outputTrackCollection ;
-  std::string m_outputTrackRelationCollection;
+  std::vector<std::string> m_inputTrackerHitCollections {};
+  std::vector<std::string> m_inputTrackerHitRelationCollections {};
+  std::string m_inputParticleCollection {};
+  std::string m_outputTrackCollection {};
+  std::string m_outputTrackRelationCollection{};
 
-  bool m_useTruthInPrefit;
-  bool m_fitForward;
+  bool m_useTruthInPrefit{};
+  bool m_fitForward{};
  	
   // Run and event counters
-  int m_eventNumber ;
-  int m_runNumber ;
+  int m_eventNumber {};
+  int m_runNumber {};
   
   // Track fit factory
-  MarlinTrk::IMarlinTrkSystem* trackFactory;
+  MarlinTrk::IMarlinTrkSystem* trackFactory{nullptr};
 
   // Track fit parameters
-  double m_initialTrackError_d0;
-  double m_initialTrackError_phi0;
-  double m_initialTrackError_omega;
-  double m_initialTrackError_z0;
-  double m_initialTrackError_tanL;
-  double m_maxChi2perHit;
-  double m_magneticField;
-  int m_fitFails;
+  double m_initialTrackError_d0{};
+  double m_initialTrackError_phi0{};
+  double m_initialTrackError_omega{};
+  double m_initialTrackError_z0{};
+  double m_initialTrackError_tanL{};
+  double m_maxChi2perHit{};
+  double m_magneticField{};
+  int m_fitFails{};
 
 		
 } ;

--- a/source/Refitting/include/TruthTracker.h
+++ b/source/Refitting/include/TruthTracker.h
@@ -80,6 +80,8 @@ public:
   
   
   TruthTracker() ;
+  TruthTracker(const TruthTracker&) = delete ;
+  TruthTracker& operator=(const TruthTracker&) = delete ;
   
   /** Called at the begin of the job before anything is read.
    * Use to initialize the processor, e.g. book histograms.
@@ -124,7 +126,7 @@ protected:
   
   const LCObjectVec* getSimHits( TrackerHit* trkhit, const FloatVec* weights = NULL);
   
-  UTIL::BitField64* _encoder;
+  UTIL::BitField64* _encoder{nullptr};
   int getDetectorID(TrackerHit* hit) { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::subdet()]; }
   int getSideID(TrackerHit* hit)     { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::side()]; };
   int getLayerID(TrackerHit* hit)    { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::layer()]; };
@@ -152,86 +154,86 @@ protected:
   
   /** input MCParticle collection
    */
-  std::string  _colNameMCParticles;
+  std::string  _colNameMCParticles{};
   
   /** input TrackerHit collections
    */
-  std::vector< std::string > _colNamesTrackerHits;
+  std::vector< std::string > _colNamesTrackerHits{};
  
   /** input relation collections 
    */
-  std::vector< std::string > _colNamesTrackerHitRelations;
+  std::vector< std::string > _colNamesTrackerHitRelations{};
 
-  std::vector< LCCollection* > _colTrackerHits;
-  std::vector< LCRelationNavigator* > _navTrackerHitRel;
+  std::vector< LCCollection* > _colTrackerHits{};
+  std::vector< LCRelationNavigator* > _navTrackerHitRel{};
   
   /** output track collection 
    */
-  std::string _output_track_col_name ;
-  LCCollectionVec* _trackVec;
+  std::string _output_track_col_name {};
+  LCCollectionVec* _trackVec{nullptr};
   
   /** Output track relations
    */
-  std::string _output_track_rel_name ;
-  LCCollectionVec* _trackRelVec;
+  std::string _output_track_rel_name {};
+  LCCollectionVec* _trackRelVec{nullptr};
 
   
   /** output track segments collection, used for tracks which cannot be formed from a single fit 
    */
-  std::string _output_track_segments_col_name ;
-  LCCollectionVec* _trackSegmentsVec;
+  std::string _output_track_segments_col_name {};
+  LCCollectionVec* _trackSegmentsVec{nullptr};
   
   /** Output track segments relations, used for tracks which cannot be formed from a single fit
    */
-  std::string _output_track_segment_rel_name ;
-  LCCollectionVec* _trackSegmentsRelVec;
+  std::string _output_track_segment_rel_name {};
+  LCCollectionVec* _trackSegmentsRelVec{nullptr};
   
-  int _nMCP;
+  int _nMCP{};
   
-  int _n_run ;
-  int _n_evt ;
+  int _n_run {};
+  int _n_evt {};
   
-  float _MCpThreshold ;
+  float _MCpThreshold {};
 
-  bool _useMCParticleParametersFotInitOfFit;
+  bool _useMCParticleParametersFotInitOfFit{};
   
   /** pointer to the IMarlinTrkSystem instance 
    */
-  MarlinTrk::IMarlinTrkSystem* _trksystem ;
-  bool _runMarlinTrkDiagnostics;
-  std::string _MarlinTrkDiagnosticsName;
+  MarlinTrk::IMarlinTrkSystem* _trksystem {nullptr};
+  bool _runMarlinTrkDiagnostics{};
+  std::string _MarlinTrkDiagnosticsName{};
 
-  bool _FitTracksWithMarlinTrk;
-  bool _create_prefit_using_MarlinTrk;
+  bool _FitTracksWithMarlinTrk{};
+  bool _create_prefit_using_MarlinTrk{};
     
-  bool _MSOn ;
-  bool _ElossOn ;
-  bool _SmoothOn ;
+  bool _MSOn {};
+  bool _ElossOn {};
+  bool _SmoothOn {};
 
-  float _initialTrackError_d0;
-  float _initialTrackError_phi0;
-  float _initialTrackError_omega;
-  float _initialTrackError_z0;
-  float _initialTrackError_tanL;
+  float _initialTrackError_d0{};
+  float _initialTrackError_phi0{};
+  float _initialTrackError_omega{};
+  float _initialTrackError_z0{};
+  float _initialTrackError_tanL{};
 
-  bool  _UseIterativeFitting;
-  bool  _UseEventDisplay;
+  bool  _UseIterativeFitting{};
+  bool  _UseEventDisplay{};
   
-  double _maxChi2PerHit;
+  double _maxChi2PerHit{};
     
-  double _Bz;
+  double _Bz{};
 
-  unsigned _nCreatedTracks;
+  unsigned _nCreatedTracks{};
   
-  EVENT::LCEvent* _current_event;
+  EVENT::LCEvent* _current_event{nullptr};
   
-  int _detector_model_for_drawing;
-  std::vector<int> _colours;  
-  float     _helix_max_r;
+  int _detector_model_for_drawing{};
+  std::vector<int> _colours{};
+  float     _helix_max_r{};
   
-  std::string _trkSystemName ;
+  std::string _trkSystemName {};
 
-  int _fitDirection ;
+  int _fitDirection {};
 } ;
 
 #endif

--- a/source/Refitting/src/DDCellsAutomatonMV.cc
+++ b/source/Refitting/src/DDCellsAutomatonMV.cc
@@ -560,7 +560,7 @@ void DDCellsAutomatonMV::processEvent( LCEvent * evt ) {
 	streamlog_out( DEBUG2 ) << "Keeping track because of good helix fit: chi2/ndf = " << chi2OverNdf << "\n";
       }
     }
-    catch( VXDHelixFitterException e ){
+    catch( VXDHelixFitterException& e ){
       
       
       streamlog_out( DEBUG2 ) << "Track rejected, because fit failed: " <<  e.what() << "\n";
@@ -610,7 +610,7 @@ void DDCellsAutomatonMV::processEvent( LCEvent * evt ) {
       
       
     }
-    catch( FitterException e ){
+    catch( FitterException& e ){
       
       streamlog_out( DEBUG4 ) << "Track rejected, because fit failed: " <<  e.what() << "\n";
       delete trackCand;
@@ -737,7 +737,7 @@ void DDCellsAutomatonMV::processEvent( LCEvent * evt ) {
 	  }
 	}
 	
-	catch( FitterException e ){
+	catch( FitterException& e ){
 	  
 	  streamlog_out( DEBUG4 ) << "DDCellsAutomatonMV: track couldn't be finalized due to fitter error: " << e.what() << "\n";
 	  delete trackImpl;

--- a/source/Refitting/src/SiliconTracking_MarlinTrk.cc
+++ b/source/Refitting/src/SiliconTracking_MarlinTrk.cc
@@ -145,8 +145,8 @@ namespace DiagnosticsHistograms {
     
   protected:
     
-    std::vector<TH1*> _h1D;
-    std::vector<TH2*> _h2D;
+    std::vector<TH1*> _h1D{};
+    std::vector<TH2*> _h2D{};
 
   };
   
@@ -2296,9 +2296,9 @@ void SiliconTracking_MarlinTrk::CreateTrack(TrackExtended * trackAR ) {
 
 	  trackAR->ClearTrackerHitExtendedVec();
 	  for (int i=0;i<nHits;++i) {
-	    int iopt = 2;
+	    int i_opt = 2;
 	    TrackerHitExtended * trkHit = hitVec[i];
-	    AttachHitToTrack(trackOld, trkHit, iopt );
+	    AttachHitToTrack(trackOld, trkHit, i_opt );
 	  }
 
 	} else { // backward compatible

--- a/source/Utils/include/CalcTrackerHitResiduals.h
+++ b/source/Utils/include/CalcTrackerHitResiduals.h
@@ -64,6 +64,8 @@ public:
   
   
   CalcTrackerHitResiduals() ;
+  CalcTrackerHitResiduals(const CalcTrackerHitResiduals&) = delete ;
+  CalcTrackerHitResiduals& operator=(const CalcTrackerHitResiduals&) = delete ;
   
   /** Called at the begin of the job before anything is read.
    * Use to initialize the processor, e.g. book histograms.
@@ -100,7 +102,7 @@ protected:
   
 
   
-  UTIL::BitField64* _encoder;
+  UTIL::BitField64* _encoder{nullptr};
   int getDetectorID(TrackerHit* hit) { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::subdet()]; }
   int getSideID(TrackerHit* hit)     { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::side()]; };
   int getLayerID(TrackerHit* hit)    { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::layer()]; };
@@ -120,29 +122,29 @@ protected:
     
   /** input TrackerHit collections
    */
-  std::vector< std::string > _colNamesTrackerHits;
+  std::vector< std::string > _colNamesTrackerHits{};
  
   /** input relation collections 
    */
-  std::vector< std::string > _colNamesTrackerHitRelations;
+  std::vector< std::string > _colNamesTrackerHitRelations{};
   
   
 //   int _nEventPrintout ;
-  int _n_run ;
-  int _n_evt ;
-  int _current_evt_number ;
+  int _n_run {};
+  int _n_evt {};
+  int _current_evt_number {};
   
   
-  std::vector< LCCollection* > _colTrackerHits;
-  std::vector< LCRelationNavigator* > _navTrackerHitRel;
+  std::vector< LCCollection* > _colTrackerHits{};
+  std::vector< LCRelationNavigator* > _navTrackerHitRel{};
     
   
-  TFile* _root_file;
+  TFile* _root_file{nullptr};
   
-  std::map<std::string, TH1F*> _histo_map;
-  std::map<std::string, TH1F*>::iterator _histo_map_it;
+  std::map<std::string, TH1F*> _histo_map{};
+  std::map<std::string, TH1F*>::iterator _histo_map_it{};
   
-  std::map<std::string, std::list<float>*> _histo_buffer_map;
+  std::map<std::string, std::list<float>*> _histo_buffer_map{};
   
   
   dd4hep::rec::SurfaceMap _surfMap{} ;

--- a/source/Utils/include/SetTrackerHitExtensions.h
+++ b/source/Utils/include/SetTrackerHitExtensions.h
@@ -56,6 +56,8 @@ public:
   
   
   SetTrackerHitExtensions() ;
+  SetTrackerHitExtensions(const SetTrackerHitExtensions&) = delete ;
+  SetTrackerHitExtensions& operator=(const SetTrackerHitExtensions&) = delete ;
   
   /** Called at the begin of the job before anything is read.
    * Use to initialize the processor, e.g. book histograms.
@@ -83,7 +85,7 @@ protected:
   
   const LCObjectVec* getSimHits( TrackerHit* trkhit, const FloatVec* weights = NULL);
   
-  UTIL::BitField64* _encoder;
+  UTIL::BitField64* _encoder{nullptr};
   int getDetectorID(TrackerHit* hit) { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::subdet()]; }
   int getSideID(TrackerHit* hit)     { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::side()]; };
   int getLayerID(TrackerHit* hit)    { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::layer()]; };
@@ -104,21 +106,21 @@ protected:
   
   /** input TrackerHit collections
    */
-  std::vector< std::string > _colNamesTrackerHits;
+  std::vector< std::string > _colNamesTrackerHits{};
  
   /** input relation collections 
    */
-  std::vector< std::string > _colNamesTrackerHitRelations;
+  std::vector< std::string > _colNamesTrackerHitRelations{};
   
   
 //   int _nEventPrintout ;
-  int _n_run ;
-  int _n_evt ;
-  int _current_evt_number ;
+  int _n_run {};
+  int _n_evt {};
+  int _current_evt_number {};
   
   
-  std::vector< LCCollection* > _colTrackerHits;
-  std::vector< LCRelationNavigator* > _navTrackerHitRel;
+  std::vector< LCCollection* > _colTrackerHits{};
+  std::vector< LCRelationNavigator* > _navTrackerHitRel{};
     
   
 } ;

--- a/source/Utils/include/SplitCollectionByLayer.h
+++ b/source/Utils/include/SplitCollectionByLayer.h
@@ -30,10 +30,10 @@ protected:
 
   ///helper struct
   struct OutColInfo{
-    std::string name ;
-    unsigned layer0 ;
-    unsigned layer1 ;
-    LCCollection* collection ;
+    std::string name {};
+    unsigned layer0 {};
+    unsigned layer1 {};
+    LCCollection* collection {nullptr};
   };
   
   /// Enum used for hit types
@@ -51,6 +51,8 @@ protected:
   
   
   SplitCollectionByLayer() ;
+  SplitCollectionByLayer(const SplitCollectionByLayer&) = delete ;
+  SplitCollectionByLayer& operator=(const SplitCollectionByLayer&) = delete ;
   
   virtual const std::string & name() const { return Processor::name() ; }
  
@@ -79,17 +81,17 @@ protected:
  protected:
 
   ////Input collection name.
-  std::string _colName ;
+  std::string _colName {};
 
   /// Output collections and layers:
-  StringVec  _outColAndLayers ;
+  StringVec  _outColAndLayers {};
 
-  std::vector<OutColInfo> _outCols ;
+  std::vector<OutColInfo> _outCols {};
 
-  HitType _type ;
+  HitType _type {};
 
-  int _nRun ;
-  int _nEvt ;
+  int _nRun {};
+  int _nEvt {};
 } ;
 
 #endif


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix warnings to make Key4hep based CI workflows pass again
- Remove CentOS7 from Key4hep based workflows since it is no longer supported

ENDRELEASENOTES