### PR TITLE
Set the subdetectorHitNumbers in ClonesAndSplitTracksFinder

### DIFF
--- a/source/Refitting/src/ClonesAndSplitTracksFinder.cc
+++ b/source/Refitting/src/ClonesAndSplitTracksFinder.cc
@@ -233,6 +233,7 @@ void ClonesAndSplitTracksFinder::fromTrackToTrackImpl(const Track* track, TrackI
   trackFinal->setNdf(track->getNdf());
   trackFinal->setdEdx(track->getdEdx());
   trackFinal->setdEdxError(track->getdEdxError());
+  trackFinal->subdetectorHitNumbers() = track->getSubdetectorHitNumbers();
 }
 
 void ClonesAndSplitTracksFinder::removeClones(EVENT::TrackVec& tracksWithoutClones, LCCollection*& input_track_col) {


### PR DESCRIPTION
when mergeSplitTracks is false. See https://github.com/key4hep/CLDConfig/issues/69. I ran the CLD reconstruction with this change and I can see the subdetector hit numbers have the same values as in the original track.

BEGINRELEASENOTES
- Set the subdetectorHitNumbers in ClonesAndSplitTracksFinder that was not being set (defaulted to 0) when `mergeSplitTracks` is false.

ENDRELEASENOTES